### PR TITLE
Fix CLI call for creating and checking relationships

### DIFF
--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -330,8 +330,8 @@ You can also [touch and delete] relationships, but those are not as immediately 
   <TabItem value="shell">
 
 ```shell
-zed relationship create blog/post:1 writer blog/user:emilia
-zed relationship create blog/post:1 reader blog/user:beatrice
+zed relationship create {{ tenant }}/post:1 writer {{ tenant }}/user:emilia
+zed relationship create {{ tenant }}/post:1 reader {{ tenant }}/user:beatrice
 ```
 
   </TabItem>
@@ -581,10 +581,10 @@ The following examples demonstrate exactly that:
   <TabItem value="shell">
 
 ```shell
-zed permission check blog/post:1 read  blog/user:emilia --revision "zedtokenfromwriterel" # true
-zed permission check blog/post:1 write blog/user:emilia --revision "zedtokenfromwriterel"  # true
-zed permission check blog/post:1 read  blog/user:beatrice --revision "zedtokenfromwriterel" # true
-zed permission check blog/post:1 write blog/user:beatrice --revision "zedtokenfromwriterel" # false
+zed permission check {{ tenant }}/post:1 read  {{ tenant }}/user:emilia --revision "zedtokenfromwriterel" # true
+zed permission check {{ tenant }}/post:1 write {{ tenant }}/user:emilia --revision "zedtokenfromwriterel"  # true
+zed permission check {{ tenant }}/post:1 read  {{ tenant }}/user:beatrice --revision "zedtokenfromwriterel" # true
+zed permission check {{ tenant }}/post:1 write {{ tenant }}/user:beatrice --revision "zedtokenfromwriterel" # false
 ```
 
   </TabItem>

--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -581,10 +581,10 @@ The following examples demonstrate exactly that:
   <TabItem value="shell">
 
 ```shell
-zed permission check post:1 read  user:emilia --revision "zedtokenfromwriterel" # true
-zed permission check post:1 write user:emilia --revision "zedtokenfromwriterel"  # true
-zed permission check post:1 read  user:beatrice --revision "zedtokenfromwriterel" # true
-zed permission check post:1 write user:beatrice --revision "zedtokenfromwriterel" # false
+zed permission check blog/post:1 read  blog/user:emilia --revision "zedtokenfromwriterel" # true
+zed permission check blog/post:1 write blog/user:emilia --revision "zedtokenfromwriterel"  # true
+zed permission check blog/post:1 read  blog/user:beatrice --revision "zedtokenfromwriterel" # true
+zed permission check blog/post:1 write blog/user:beatrice --revision "zedtokenfromwriterel" # false
 ```
 
   </TabItem>

--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -329,10 +329,12 @@ You can also [touch and delete] relationships, but those are not as immediately 
 ]}>
   <TabItem value="shell">
 
-```shell
+<SampleCodeBlock lang="shell">
+{`
 zed relationship create {{ tenant }}/post:1 writer {{ tenant }}/user:emilia
 zed relationship create {{ tenant }}/post:1 reader {{ tenant }}/user:beatrice
-```
+`}
+</SampleCodeBlock>
 
   </TabItem>
   <TabItem value="go">
@@ -580,12 +582,14 @@ The following examples demonstrate exactly that:
 ]}>
   <TabItem value="shell">
 
-```shell
+<SampleCodeBlock lang="shell">
+{`
 zed permission check {{ tenant }}/post:1 read  {{ tenant }}/user:emilia --revision "zedtokenfromwriterel" # true
 zed permission check {{ tenant }}/post:1 write {{ tenant }}/user:emilia --revision "zedtokenfromwriterel"  # true
 zed permission check {{ tenant }}/post:1 read  {{ tenant }}/user:beatrice --revision "zedtokenfromwriterel" # true
 zed permission check {{ tenant }}/post:1 write {{ tenant }}/user:beatrice --revision "zedtokenfromwriterel" # false
-```
+`}
+</SampleCodeBlock>
 
   </TabItem>
   <TabItem value="go">

--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -330,8 +330,8 @@ You can also [touch and delete] relationships, but those are not as immediately 
   <TabItem value="shell">
 
 ```shell
-zed relationship create posts:1 writer user:emilia
-zed relationship create posts:1 reader user:beatrice
+zed relationship create blog/post:1 writer blog/user:emilia
+zed relationship create blog/post:1 reader blog/user:beatrice
 ```
 
   </TabItem>


### PR DESCRIPTION
The CLI call was broken because the names didn't line up. It seems to be fine for the other language examples.