### PR TITLE
docs: fix homebrew installation command

### DIFF
--- a/docs/spicedb/installing.md
+++ b/docs/spicedb/installing.md
@@ -31,7 +31,7 @@ docker run --name spicedb \
 ### brew
 
 ```sh
-brew install spicedb
+brew install authzed/tap/spicedb
 ```
 
 ```sh


### PR DESCRIPTION
This PR:

- [x] Updates the installation instructions for homebrew users.

The current installation command does not work directly because it assumes that Authzed's tap has already been installed.