### PR TITLE
first-app: Make first Go example compile

### DIFF
--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -144,7 +144,6 @@ EOF
 import (
 	"context"
 	"log"
-	"os"
 ·
 	pb "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
@@ -178,7 +177,7 @@ func main() {
 	}
 ·
 	request := &pb.WriteSchemaRequest{Schema: schema}
-	resp, err := client.WriteSchema(context.Background(), request)
+	_, err = client.WriteSchema(context.Background(), request)
 	if err != nil {
 		log.Fatalf("failed to write schema: %s", err)
 	}


### PR DESCRIPTION
As-is, the first Go example in the Protecting your first app doesn't run because of an unused import and an unused variable.