### PR TITLE
Fix relation in defining-a-subject-type.md

### DIFF
--- a/docs/guides/defining-a-subject-type.md
+++ b/docs/guides/defining-a-subject-type.md
@@ -122,7 +122,7 @@ Or via a token it was granted, by use of a reference to a *subject relation*:
 definition token {}
 
 definition service {
-    token: token
+    relation token: token
 }
 
 definition resource {


### PR DESCRIPTION
I'm pretty sure

```
definition service {
    token: token
}
```

is supposed to be 

```
definition service {
    relation token: token
}
```

but let me know if I'm misunderstanding something. Thanks!