### PR TITLE
Link to article explaining how to enable HTTP API

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -28,6 +28,9 @@ This is accomplished by using the [gRPC Gateway], which translates requests into
 The API is documented via [OpenAPI], but may have breaking changes in the future.
 Once the API has stablized, this functionality will become available for Authzed users.
 
+Learn more about the HTTP API by reading [Have you met...our HTTP API?].
+
+[Have you met...our HTTP API?]: https://authzed.com/blog/authzed-http-api/
 [gRPC Gateway]: https://github.com/grpc-ecosystem/grpc-gateway
 [OpenAPI]: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/authzed/authzed-go/main/proto/apidocs.swagger.json
 


### PR DESCRIPTION
The documentation surrounding the HTTP API is a little misleading. When I read the documentation, I came to the conclusion that I needed to setup my own gRPC Gateway service. Only after asking a question in the Discord channel did I learn about the article that explains how to enable the HTTP API.