### PR TITLE
Replace swaggerhub with postman link

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,7 +32,7 @@ Learn more about the HTTP API by reading [Have you met...our HTTP API?].
 
 [Have you met...our HTTP API?]: https://authzed.com/blog/authzed-http-api/
 [gRPC Gateway]: https://github.com/grpc-ecosystem/grpc-gateway
-[OpenAPI]: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/authzed/authzed-go/main/proto/apidocs.swagger.json
+[OpenAPI]: https://www.postman.com/authzed/workspace/spicedb/overview
 
 ## Versioning & Deprecation Policy
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -97,4 +97,4 @@ curl -H "Authorization: Bearer myapikey" -X POST localhost:443/v1/schema/read
 
 [SpiceDB]: https://github.com/authzed/spicedb
 [curl]: https://curl.se
-[openapi]: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/authzed/authzed-go/main/proto/apidocs.swagger.json
+[openapi]: https://www.postman.com/authzed/workspace/spicedb/overview

--- a/docs/spicedb/feature-overview.md
+++ b/docs/spicedb/feature-overview.md
@@ -45,7 +45,7 @@ The API is documented via [OpenAPI], but may have breaking changes in the future
 For more information, see the [API Overview].
 
 [gRPC Gateway]: https://github.com/grpc-ecosystem/grpc-gateway
-[OpenAPI]: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/authzed/authzed-go/main/proto/apidocs.swagger.json
+[OpenAPI]: https://www.postman.com/authzed/workspace/spicedb/overview
 [API Overview]: /reference/api.md
 
 ### Datastore

--- a/sidebars.js
+++ b/sidebars.js
@@ -9,7 +9,7 @@ module.exports = {
     {
       type: 'link',
       label: 'REST API Reference',
-      href: 'https://app.swaggerhub.com/apis-docs/authzed/authzed/1.0',
+      href: 'https://www.postman.com/authzed/workspace/spicedb/overview',
     },
     'support',
     {
@@ -22,7 +22,7 @@ module.exports = {
         'guides/defining-a-subject-type',
         'guides/writing-relationships',
         'guides/validation-and-testing',
-        'guides/debugging'
+        'guides/debugging',
       ],
     },
     {
@@ -67,6 +67,6 @@ module.exports = {
           href: 'https://buf.build/authzed/api/docs/main:authzed.api.v1',
         },
       ],
-    }
+    },
   ],
 };


### PR DESCRIPTION
Also refreshed the SpiceDB postman workspace with openapi generated docs:
https://www.postman.com/authzed/workspace/c1b9ce6b-7482-4363-8a09-71521355b6d9/api/c7764854-8b04-4441-8360-a6b2f1d52064