### PR TITLE
Addresses SpiceDB issue 1072

### DIFF
--- a/docs/spicedb/installing.md
+++ b/docs/spicedb/installing.md
@@ -32,7 +32,6 @@ docker pull authzed/spicedb
 ```sh
 docker run --name spicedb \
     -p 50051:50051 \
-    --rm \
     authzed/spicedb serve \
     --grpc-preshared-key "somerandomkeyhere"
 ```


### PR DESCRIPTION
According to [SpiceDB Issue 1072](https://github.com/authzed/spicedb/issues/1072), `--rm ` in the shared command for a Docker based installation is causing persistence issues with the SpiceDB docker container.