### PR TITLE
fix CheckPermissionRequest schema in caveats.md

### DIFF
--- a/docs/reference/caveats.md
+++ b/docs/reference/caveats.md
@@ -286,7 +286,7 @@ CheckPermissionRequest {
         ObjectType: "resource",
         ObjectId: "someresource",
     },
-    Relation: "view",
+    Permission: "view",
     Subject: {
         ObjectType: "user",
         ObjectId: "sarah",


### PR DESCRIPTION
The `CheckPermissionRequest` example is incorrect — rather than specifying the `Relation` field, the example should specify the `Permission` field.