### PR TITLE
Adding actions/checkout@v3 to github action docs

### DIFF
--- a/docs/guides/validation-and-testing.md
+++ b/docs/guides/validation-and-testing.md
@@ -29,6 +29,7 @@ This functionality is also provided in the form of a [GitHub Action], for use in
 
 ```yaml
 steps:
+- uses: "actions/checkout@v3"
 - uses: "authzed/action-spicedb-validate@v1"
   with:
     validationfile: "myschema.zaml"


### PR DESCRIPTION
This step is necessary to successfully use the zed validate github action. 