### PR TITLE
read baseURL from environment

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,7 @@ module.exports = {
     'Documentation for Authzed, the planet-scale, serverless database platform for SpiceDB.',
   favicon: 'img/favicon.svg',
   url: 'https://authzed.com',
-  baseUrl: '/docs/',
+  baseUrl: env('DOCUSAURUS_BASE_URL', '/'),
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   staticDirectories: ['static'],


### PR DESCRIPTION
This change reads the baseURL from the environment.
This fixes a bug where previews need a value of `/` but production uses `/docs/`.