### PR TITLE
Override robots header for proxied requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,37 @@
 {
   "version": 2,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "authzed.com"
+        }
+      ],
+      "headers": [
+        {
+          "key": "x-robots-tag",
+          "value": "index, follow"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs-authzed.vercel.app"
+        }
+      ],
+      "headers": [
+        {
+          "key": "x-robots-tag",
+          "value": "index, follow"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/",


### PR DESCRIPTION
Overriding the automatically set header value for proxied requests from authzed.com 