### PR TITLE
Fixes initial Python Client connect code in "Defining and Applying a Schema"

### DIFF
--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -228,8 +228,7 @@ definition {{ tenant }}/post {
 ·
 client = Client(
     "{{ endpoint }}",
-    {% if authzed %}bearer_token_credentials("{{ token }}"),{% endif %}
-{% if not authzed %}# For SpiceDB behind TLS, use:
+    {% if not authzed %}# For SpiceDB behind TLS, use:
     # bearer_token_credentials("{{ token }}"),
     insecure_{% endif %}bearer_token_credentials("{{ token }}"),
 )


### PR DESCRIPTION
Guide at: https://authzed.com/docs/guides/first-app in section **Defining and Applying a Schema** generates incorrect Python example when using `I have an [Authzed permissions system](https://app.authzed.com/) created` option.

Before:

```
client = Client(
    "grpc.authzed.com:443",
    bearer_token_credentials("t_your_token_here_1234567deadbeef"),bearer_token_credentials("t_your_token_here_1234567deadbeef"),
)
```
(`bearer_token_credentials` gets repeated twice).

This PR fixes this to generate a version of code that works:

```
client = Client(
    "grpc.authzed.com:443",
    bearer_token_credentials("t_your_token_here_1234567deadbeef"),
)
```

