### PR TITLE
Fix relative doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ It's built with [Docusaurus] v2.
 [Docusaurus]: https://docusaurus.io
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to contribute and perform common tasks like building the project and running tests.
+
+## Getting Started
+
+Install dependencies:
+
+```
+pnpm install
+```
+
+Run a development server:
+
+```
+pnpm run start
+```

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -2,8 +2,8 @@
 
 While it is recommended that SpiceDB [schema] be [validated and tested] before production deployment, there are many scenarios in which being able to see the _actual_ paths taken against production data is incredibly important.
 
-[schema]: schema
-[validated and tested]: validation-and-testing
+[schema]: ./schema.md
+[validated and tested]: ./validation-and-testing.md
 
 To support this use case the CheckPermission API supports a special debug header which can be used to retrieve the _full_ set of relations and permission traversed in order to compute the result.
 

--- a/docs/guides/defining-a-subject-type.md
+++ b/docs/guides/defining-a-subject-type.md
@@ -94,7 +94,7 @@ definition document {
 }
 ```
 
-[wildcards]: /reference/schema-lang#wildcards
+[wildcards]: /reference/schema-lang.md#wildcards
 
 :::note
 It is recommended to use *wildcard* with an anonymous user definition if there is ever a need to differentiate between anonymous users based on their object IDs.

--- a/docs/guides/first-app.mdx
+++ b/docs/guides/first-app.mdx
@@ -21,9 +21,9 @@ One of:
 - A [running instance] of [SpiceDB][SpiceDB] with the configured preshared key for SpiceDB
 
 [Authzed]: https://app.authzed.com
-[API Token]: /reference/api#authentication
+[API Token]: /reference/api.md#authentication
 [SpiceDB]: https://github.com/authzed/spicedb
-[running instance]: /spicedb/installing
+[running instance]: /spicedb/installing.md
 
 <SampleConfigEditor/>
 

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -10,7 +10,7 @@ Examples of object types include resources, users, groups, documents, or any kin
 
 For the exhaustive description of the language used to write schemas, check out the [schema language reference].
 
-[schema language reference]: /reference/schema-lang
+[schema language reference]: ../reference/schema-lang.md
 [spicedb]: https://github.com/authzed/spicedb
 [authzed]: https://app.authzed.com
 
@@ -100,7 +100,7 @@ Can a specific user read the specific document?
 To add this question for validation in the Authzed Playground, we must translate the question into the _Test Relationships_ and the _Assertions_.
 
 [checkpermission]: https://buf.build/authzed/api/docs/main:authzed.api.v1#CheckPermission
-[subject]: /guides/defining-a-subject-type
+[subject]: /guides/defining-a-subject-type.md
 
 ### Creating test relationships
 

--- a/docs/guides/writing-relationships.md
+++ b/docs/guides/writing-relationships.md
@@ -2,7 +2,7 @@
 
 In [SpiceDB], a permissions system is defined by two items: the [schema] which defines *how* data can be represented, and the *relationships*, defining the way the objects are actually related to one another.
 
-[schema]: /guides/schema
+[schema]: /guides/schema.md
 [SpiceDB]: https://github.com/authzed/spicedb
 
 It is the application's responsibility to keep the relationships within SpiceDB up-to-date and reflecting the state of the application; how an application does so can vary based on the specifics of the application, so below we outline a few approaches.
@@ -51,14 +51,14 @@ try:
   tx = db.transaction()
 
   # Write relationships during a transaction so that it can be aborted on exception
-  resp = spicedb_client.WriteRelationships(...) 
+  resp = spicedb_client.WriteRelationships(...)
 
   tx.add(db_models.Document(
     id=request.document_id,
     owner=user_id,
     zedtoken=resp.written_at
-  )) 
-  tx.commit() 
+  ))
+  tx.commit()
 except:
   # Delete relationships written to SpiceDB and re-raise the exception
   tx.abort()

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -105,15 +105,14 @@ Log into the [Authzed dashboard] to create a serverless SpiceDB instance or [run
 Join us on [Discord] to discuss any questions you may have!
 
 [discord]: https://authzed.com/discord
-[run spicedb]: /spicedb/installing
+[run spicedb]: spicedb/installing.md
 [authzed]: https://authzed.com
 [authzed dashboard]: https://app.authzed.com
 [spicedb]: https://github.com/authzed/spicedb
-[developing a schema]: /guides/schema
+[developing a schema]: guides/schema.md
 [watch a video]: https://www.youtube.com/watch?v=x3-B9-ICj0w
 [design documentation]: https://authzed.com/docs/reference/schema-lang
 [jump into the playground]: https://play.authzed.com
-[protecting your first app]: /guides/first-app
 [buf registry]: https://buf.build/authzed/api/docs
 [install zed]: https://github.com/authzed/zed
 [read the authzed blog]: https://authzed.com/blog

--- a/docs/reference/caveats.md
+++ b/docs/reference/caveats.md
@@ -278,8 +278,8 @@ CheckPermissionRequest {
 
 The [Assertions] and [Expected Relations] definitions for validation of schema support caveats as well.
 
-[assertions]: /guides/schema#writing-assertions
-[expected relations]: /guides/schema#writing-expected-relations
+[assertions]: /guides/schema.md#writing-assertions
+[expected relations]: /guides/schema.md#writing-expected-relations
 
 ### Assertions
 

--- a/docs/reference/schema-lang.md
+++ b/docs/reference/schema-lang.md
@@ -50,7 +50,7 @@ Objects are used to represent both resources and subjects.
 
 See the [caveats guide] to learn more about caveats.
 
-[caveats guide]: /reference/caveats
+[caveats guide]: /reference/caveats.md
 
 ## Relations
 

--- a/docs/spicedb-dedicated/networking/aws.md
+++ b/docs/spicedb-dedicated/networking/aws.md
@@ -5,7 +5,7 @@ Most users of SpiceDB Dedicated privately connect to SpiceDB with AWS [PrivateLi
 
 ## Connect to SpiceDB Dedicated with PrivateLink
 
-![/img/aws_dedicated_diagram.png](/img/aws_dedicated_diagram.png)
+<img src={require("/img/aws_dedicated_diagram.png").default} alt="Network Diagram" />
 
 ### Prerequisites
 

--- a/docs/spicedb-dedicated/overview.md
+++ b/docs/spicedb-dedicated/overview.md
@@ -21,8 +21,8 @@ Additionally, the following can be purchased by SpiceDB Dedicated users:
 
 For more information, you can review the [pricing page] or [schedule an introductory call]
 
-[gold support]: /support#gold-support
-[silver support]: /support#silver-support
+[gold support]: /support.md#gold-support
+[silver support]: /support.md#silver-support
 [pricing page]: https://authzed.com/pricing
 [schedule an introductory call]: https://authzed.com/contact/?utm_source=docs
 

--- a/docs/spicedb-serverless/overview.md
+++ b/docs/spicedb-serverless/overview.md
@@ -14,9 +14,9 @@ The billing model for this service is **usage-based**.
 
 Customers are **charged monthly** based on two dimensions: the number of [relationships] stored in Authzed, and the number of [dispatched operations] made when performing [API] calls.
 
-[relationships]: /reference/glossary#relationship
+[relationships]: /reference/glossary.md#relationship
 [dispatched operations]: #what-counts-as-a-dispatched-operation
-[api]: /reference/api
+[api]: /reference/api.md
 [authzed]: https://app.authzed.com
 
 | Dimension             | Price Per 1 miliion |
@@ -46,7 +46,7 @@ A **dispatched operation** is a single _non-cached_ operation performed by Authz
 
 The number of dispatched operations depends heavily on the type of [API] being called, the complexity of the permissions system's [schema] and how many of those operations have been cached from previous [API] calls.
 
-[schema]: /guides/schema
+[schema]: /guides/schema.md
 
 #### API Dispatch Estimation
 

--- a/docs/spicedb/configuring-dispatch.md
+++ b/docs/spicedb/configuring-dispatch.md
@@ -4,7 +4,7 @@
 If you are deploying SpiceDB under Kubernetes, it is recommended to use the [SpiceDB Operator], which will configure dispatching automatically
 :::
 
-[spicedb operator]: /spicedb/operator
+[spicedb operator]: /spicedb/operator.md
 
 ## What is Dispatching?
 

--- a/docs/spicedb/enabling-watch-api.md
+++ b/docs/spicedb/enabling-watch-api.md
@@ -3,7 +3,7 @@
 The [Watch API] is by default enabled for most [datastores].
 
 [watch api]: https://buf.build/authzed/api/docs/main:authzed.api.v1#authzed.api.v1.WatchService.Watch
-[datastores]: selecting-a-datastore
+[datastores]: selecting-a-datastore.md
 
 However, Postgres and CockroachDB require special flags in order to enable the watch API, as they depend upon features not enabled by default in most installations.
 

--- a/docs/spicedb/installing.md
+++ b/docs/spicedb/installing.md
@@ -13,7 +13,7 @@ The recommended way to install SpiceDB for a production system is with the opera
 
 The other installation options below can be helpful to test SpiceDB locally, or to run on a non-Kubernetes system.
 
-[operator docs]: /spicedb/operator
+[operator docs]: /spicedb/operator.md
 
 ## Other install options
 
@@ -46,7 +46,7 @@ brew install authzed/tap/spicedb
 spicedb serve --grpc-preshared-key "somerandomkeyhere"
 ```
 
-[selecting a datastore]: /spicedb/selecting-a-datastore
+[selecting a datastore]: /spicedb/selecting-a-datastore.md
 
 ### Download the binary
 
@@ -75,7 +75,7 @@ A variety of [clients/tools] can be used to interact with the API.
 
 [zed] is the official CLI client and can be used to check that SpiceDB is running, write schema and relationships, and perform other operations against SpiceDB:
 
-[clients/tools]: /reference/clients
+[clients/tools]: /reference/clients.md
 [zed]: https://github.com/authzed/zed
 
 ### Running via brew
@@ -117,5 +117,5 @@ Config values are parsed with the following precedence:
 
 Continue with the [Protecting Your First App] guide to learn how to use SpiceDB to protect your application and read [Configuring Dispatching] to learn more about how to configure your SpiceDB for production-level dispatching and caching.
 
-[protecting your first app]: /guides/first-app
-[configuring dispatching]: /spicedb/configuring-dispatch
+[protecting your first app]: /guides/first-app.mdx
+[configuring dispatching]: /spicedb/configuring-dispatch.md

--- a/docs/spicedb/operator.md
+++ b/docs/spicedb/operator.md
@@ -38,7 +38,7 @@ For example, TLS is disabled and data is not persisted when SpiceDB is shut down
 See the guide for [selecting a datastore].
 :::
 
-[selecting a datastore]: /spicedb/selecting-a-datastore
+[selecting a datastore]: /spicedb/selecting-a-datastore.md
 
 You can now create and configure SpiceDB clusters by writing a `SpiceDBCluster` objects.
 For example:
@@ -80,7 +80,7 @@ A variety of [clients/tools] can be used to interact with the API.
 
 [zed] is the official CLI client and can be used to check that SpiceDB is running, write schema and relationships, and perform other operations against SpiceDB:
 
-[clients/tools]: /reference/clients
+[clients/tools]: /reference/clients.md
 [zed]: https://github.com/authzed/zed
 
 #### Running via brew

--- a/docs/spicedb/selecting-a-datastore.md
+++ b/docs/spicedb/selecting-a-datastore.md
@@ -27,7 +27,7 @@ spicedb migrate head --datastore-engine $DESIRED_ENGINE --datastore-conn-uri $CO
 If you want to use the Watch API with CockroachDB, an additional capability must be enabled within the database. See [Enabling Watch API for CRDB]
 :::
 
-[enabling watch api for crdb]: enabling-watch-api#crdb
+[enabling watch api for crdb]: enabling-watch-api.md#crdb
 
 ### Usage Notes
 
@@ -211,7 +211,7 @@ Example: `--datastore-conn-uri="username:password@(localhost:3306)/spicedb?parse
 If you want to use the Watch API with PostgreSQL, an additional capability must be enabled within the database. See [Enabling Watch API for PostgreSQL]
 :::
 
-[enabling watch api for postgresql]: enabling-watch-api#postgres
+[enabling watch api for postgresql]: enabling-watch-api.md#postgres
 
 :::note
 The minimum supported PostgreSQL version is 13.8
@@ -271,7 +271,7 @@ The minimum supported PostgreSQL version is 13.8
 If you need an ephemeral datastore designed for validation or testing, see the test server system in [Validating and Testing]
 :::
 
-[validating and testing]: /guides/validation-and-testing
+[validating and testing]: /guides/validation-and-testing.md
 
 ### Developer Notes
 

--- a/docs/spicedb/updating.md
+++ b/docs/spicedb/updating.md
@@ -61,8 +61,8 @@ No matter which service you select, zero-downtime migrations are always performe
 If you are operating SpiceDB yourself, the recommended update workflow is to use the [SpiceDB Operator].
 Please see the [operator-specific update docs] for various update options.
 
-[SpiceDB Operator]: /spicedb/operator
-[operator-specific update docs]: /spicedb/operator#updating-managed-spicedbclusters
+[SpiceDB Operator]: /spicedb/operator.md
+[operator-specific update docs]: /spicedb/operator.md#updating-managed-spicedbclusters
 
 ### Sequential Updates
 


### PR DESCRIPTION
- Document pnpm in README
- Fix relative path links to use file paths

Using file path in links takes advantage of broken link detection at build time and incorporates base path settings. https://docusaurus.io/docs/markdown-features/links
