### PR TITLE
document SpiceDB Serverless HTTP Gateway

### DIFF
--- a/docs/spicedb-serverless/overview.md
+++ b/docs/spicedb-serverless/overview.md
@@ -8,6 +8,15 @@
 
 [spicedb serverless]: https://app.authzed.com/?utm_source=docs&utm_content=spicedb+serverless
 
+## Endpoints
+
+Your permission systems will be reachable via gRPC and HTTP endpoints:
+
+- gRPC: grpc.authzed.com
+- HTTP REST: [gateway-alpha.authzed.com](https://gateway-alpha.authzed.com)
+
+A [Postman Collection](https://www.postman.com/authzed/workspace/spicedb/api) exists to help folks getting started with the REST API.
+
 ## Pricing
 
 The billing model for this service is **usage-based**.


### PR DESCRIPTION
The endpoint for HTTP Gateway
in SpiceDB serverless isn't properly
documented. Additionally a postman
collection exists that can help onboard
folks but is also undiscoverable.