### PR TITLE
add documentation around MySQL and Postgres replica support in SpiceDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ See [CONTRIBUTING.md](/CONTRIBUTING.md) for instructions on how to contribute an
 
 ## Getting Started
 
+Install pnpm:
+
+```sh
+brew install pnpm
+```
+
 Install dependencies:
 
-```
+```sh
 pnpm install
 ```
 
 Run a development server:
 
-```
+```sh
 pnpm run dev
 ```
+
+Now you should be able to see the docs rendered at http://localhost:3000

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -28,8 +28,11 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | Flag | Description | Default |
 | --- | --- | --- |
 | --datastore-conn-uri | connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb") |  |
+| --datastore-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
+| --—datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
+| --—datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
 | -h, --help | help for serve |  |
@@ -74,6 +77,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
 | --datastore-prometheus-metrics | set to false to disabled prometheus metrics from the datastore | `true` |
 | --datastore-query-userset-batch-size | number of usersets after which a relationship query will be split into multiple queries | `1024` |
+| --datastore-read-replica-conn-pool |  |  |
 | --datastore-readonly | set the service to read-only mode |  |
 | --datastore-request-hedging | enable request hedging | `true` |
 | --datastore-request-hedging-initial-slow-value | initial value to use for slow datastore requests, before statistics have been collected (default 10ms) |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -81,7 +81,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas; only supported for postgres and mysqls (e.g. "postgres://postgres:password@localhost:5432/spicedb\") |  |
 | --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `30s` |
 | --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only remote replica datastore's connection pool | `30m` |
-| --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only remote replica datastore's connection pool | `30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime) |  |
 | --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
 | --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only remote replica datastore's connection pool | `20` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -28,11 +28,11 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | Flag | Description | Default |
 | --- | --- | --- |
 | --datastore-conn-uri | connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb") |  |
-| --datastore-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
+| --datastore-credentials-provider-name | retrieve datastore credentials dynamically using aws-iam |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
-| --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
+| --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using aws-iam |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
 | -h, --help | help for serve |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -80,7 +80,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-readonly | set the service to read-only mode |  |
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas; only supported for postgres and mysqls (e.g. "postgres://postgres:password@localhost:5432/spicedb\") |  |
 | --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `30s` |
-| --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only remote replica datastore's connection pool | `30m` |
+| --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) |  |
 | --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -32,7 +32,7 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
-| --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using aws-iam |  |
+| --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using one of the following options: aws-iam |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
 | -h, --help | help for serve |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -31,8 +31,8 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | --datastore-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
-| --—datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
-| --—datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
+| -—datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
+| -—datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
 | -h, --help | help for serve |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -28,7 +28,7 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | Flag | Description | Default |
 | --- | --- | --- |
 | --datastore-conn-uri | connection string used by remote datastores (e.g. "postgres://postgres:password@localhost:5432/spicedb") |  |
-| --datastore-credentials-provider-name | retrieve datastore credentials dynamically using aws-iam |  |
+| --datastore-credentials-provider-name | retrieve datastore credentials dynamically using one of the following options: aws-iam |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -31,7 +31,7 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | --datastore-credentials-provider-name | retrieve datastore credentials dynamically using one of the following options: aws-iam |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
-| --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
+| --datastore-read-replica-conn-uri | comma-separated string of replica host URIs used by Postgres and MySQL datastores for read replicas. Note: MySQL datastores can only point to a list of replica host URIs; never use a load balancer URI. Postgres datastores can point to either a list of replica host URIs or to a load balancer |  |
 | --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using one of the following options: aws-iam |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
@@ -78,7 +78,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-prometheus-metrics | set to false to disabled prometheus metrics from the datastore | `true` |
 | --datastore-query-userset-batch-size | number of usersets after which a relationship query will be split into multiple queries | `1024` |
 | --datastore-readonly | set the service to read-only mode |  |
-| --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas; only supported for postgres and mysqls (e.g. "postgres://postgres:password@localhost:5432/spicedb\") |  |
+| --datastore-read-replica-conn-uri | comma-separated string of replica host URIs used by Postgres and MySQL datastores for read replicas. Note: MySQL datastores can only point to a list of replica host URIs; never use a load balancer URI. Postgres datastores can point to either a list of replica host URIs or to a load balancer |  |
 | --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `30s` |
 | --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -84,7 +84,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime) |  |
 | --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
-| --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
+| --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `20` |
 | --datastore-request-hedging | enable request hedging | `true` |
 | --datastore-request-hedging-initial-slow-value | initial value to use for slow datastore requests, before statistics have been collected (default 10ms) |  |
 | --datastore-request-hedging-max-requests | maximum number of historical requests to consider | `1000000` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -82,7 +82,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `30s` |
 | --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only remote replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |
-| --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime) |  |
+| --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) |  |
 | --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
 | --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `20` |
 | --datastore-request-hedging | enable request hedging | `true` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -79,7 +79,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-query-userset-batch-size | number of usersets after which a relationship query will be split into multiple queries | `1024` |
 | --datastore-readonly | set the service to read-only mode |  |
 | --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas; only supported for postgres and mysqls (e.g. "postgres://postgres:password@localhost:5432/spicedb\") |  |
-| --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only remote replica datastore's connection pool | `30s` |
+| --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `30s` |
 | --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only remote replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only remote replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime) |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -77,8 +77,14 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
 | --datastore-prometheus-metrics | set to false to disabled prometheus metrics from the datastore | `true` |
 | --datastore-query-userset-batch-size | number of usersets after which a relationship query will be split into multiple queries | `1024` |
-| --datastore-read-replica-conn-pool |  |  |
 | --datastore-readonly | set the service to read-only mode |  |
+| --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas; only supported for postgres and mysqls (e.g. "postgres://postgres:password@localhost:5432/spicedb\") |  |
+| --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only remote replica datastore's connection pool | `30s` |
+| --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only remote replica datastore's connection pool | `30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only remote replica datastore's connection pool | `30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection (default: 20% of max lifetime) |  |
+| --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
+| --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
 | --datastore-request-hedging | enable request hedging | `true` |
 | --datastore-request-hedging-initial-slow-value | initial value to use for slow datastore requests, before statistics have been collected (default 10ms) |  |
 | --datastore-request-hedging-max-requests | maximum number of historical requests to consider | `1000000` |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -83,7 +83,7 @@ This command serves the gRPC and HTTP APIs by default.
 | --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `30m` |
 | --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) |  |
-| --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only remote replica datastore's connection pool | `20` |
+| --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only replica datastore's connection pool | `20` |
 | --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `20` |
 | --datastore-request-hedging | enable request hedging | `true` |
 | --datastore-request-hedging-initial-slow-value | initial value to use for slow datastore requests, before statistics have been collected (default 10ms) |  |

--- a/pages/spicedb/concepts/commands.mdx
+++ b/pages/spicedb/concepts/commands.mdx
@@ -31,8 +31,8 @@ The following are configuration flags that can be provided to every SpiceDB comm
 | --datastore-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-engine | type of datastore to initialize ("cockroachdb", "mysql", "postgres", "spanner") | `memory` |
 | --datastore-mysql-table-prefix | prefix to add to the name of all SpiceDB database tables |  |
-| -—datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
-| -—datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
+| --datastore-read-replica-conn-uri | connection string used by remote datastores for read replicas (e.g. \"postgres://postgres:password@localhost:5432/spicedb\"). Only supported for postgres and mysql. |  |
+| --datastore-read-replica-credentials-provider-name | retrieve datastore credentials dynamically using (%s) |  |
 | --datastore-spanner-credentials | path to service account key credentials file with access to the cloud spanner instance (omit to use application default credentials) |  |
 | --datastore-spanner-emulator-host | URI of spanner emulator instance used for development and testing (e.g. localhost:9010) |  |
 | -h, --help | help for serve |  |

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -30,49 +30,6 @@ spicedb migrate head \
 
 For more information, refer to the [Datastore Migration documentation](/spicedb/concepts/datastore-migrations).
 
-## Read replicas for Postgres and MySQL
-
-SpiceDB can query read-only replicas of permissions data stored in Postgres and MySQL while maintaining consistency guarantees by detecting if a given revision has been replicated from the primary datastore before reading from the replica.
-If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
-
-When using multiple replicas, the queried replica will be chosen in a round-robin fashion.
-Please note that the maximum replica count is 16.
-
-Traffic using `minimize_latency` will benefit the most from using read replicas.
-
-### PostgreSQL read replicas
-
-You can use a load balancer between PostgreSQL replicas and SpiceDB.
-If you are not using a load balancer, you can, alternatiely, list each hostname individually.
-
-### MySQL read replicas
-
-<Callout type="warning">
-Do not use a load balancer between SpiceDB and MySQL replicas because SpiceDB will not be able to maintain consistency guarantees.
-</Callout>
-When using MySQL replicas, each hostname must be listed individually.
-
-### Configuration
-
-#### Required Parameters
-
-| Parameter            | Description                               | Example                                                                                   |
-| -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `datastore-engine`   | the datastore engine                      | `--datastore-engine=postgres`                                                          |
-| `datastore-read-replica-conn-uri` | Connection string used by datastores for read replicas; only supported for postgres and MySQL | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
-
-#### Optional Parameters
-
-| Parameter            | Description                               | Example                                                                                   |
-| -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using aws-iam                      |                 |
-| --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-healthcheck-interval=30s` |
-| --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-idletime=30m` |
-| --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-lifetime=30m` |
-| --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) | `--datastore-read-replica-conn-pool-read-max-lifetime-jitter=6m` |
-| --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-open=20` |
-| --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-min-open=20` |
-
 ## CockroachDB
 
 ### Usage Notes
@@ -221,6 +178,7 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 - Setup and operational complexity of running PostgreSQL
 - Does not rely on any non-standard PostgreSQL extensions
 - Compatible with managed PostgreSQL services (e.g. AWS RDS)
+- Can be scaled out on read workloads using read replicas
 
 <Callout type="warning">
   SpiceDB's Watch API requires PostgreSQL's [Commit Timestamp tracking][commit-ts] to be enabled.
@@ -241,6 +199,29 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 [pg-code]: https://github.com/authzed/spicedb/tree/main/internal/datastore/postgres
 [pg-godoc]: https://pkg.go.dev/github.com/authzed/spicedb/internal/datastore/postgres
 [mvcc]: https://en.wikipedia.org/wiki/Multiversion_concurrency_control
+
+### Read Replicas
+
+SpiceDB supports Postgres read replicas and does it while retaining consistency guarantees.
+Typical use cases are:
+
+- scale read workloads/offload reads from the primary
+- deploy SpiceDB in other regions with primarily read workloads
+
+Read replicas are typically configured with asynchronous replication, which involves replication lag.
+That would be problematic to SpiceDB's ability to solve the new enemy problem but it addresses the challenge by checking if a revision has been replicated into the target replica.
+If missing, it will fall back to the primary.
+
+All API consistency options will leverage replicas, but the ones that benefit the most are those that involve some level of staleness as it increases the odds a revision has replicated.
+`minimize_latency`, `at_least_as_fresh`, and `at_exact_snapshot` consistency modes have the highest chance of being redirected to a replica.
+
+SpiceDB supports Postgres replicas behind a load-balancer, and/or individually listing replica hosts.
+When multiple URIs are provided, they will be queried using a round-robin strategy.  
+Please note that the maximum number of replica URIs to list is 16.
+
+Read replicas are configured with the `--datastore-read-replica-*` family of flags.
+
+SpiceDB supports [PgBouncer](https://www.pgbouncer.org/) connection pooler and is part of the test suite.
 
 ### Configuration
 
@@ -263,6 +244,14 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 | `datastore-gc-window`                 | Sets the window outside of which overwritten relationships are no longer accessible | `--datastore-gc-window=1s`                   |
 | `datastore-revision-fuzzing-duration` | Sets a fuzzing window on all zookies/zedtokens                                      | `--datastore-revision-fuzzing-duration=50ms` |
 | `datastore-readonly`                  | Places the datastore into readonly mode                                             | `--datastore-readonly=true`                  |
+| `datastore-read-replica-conn-uri`     | Connection string used by datastores for read replicas; only supported for postgres and MySQL | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
+| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using aws-iam                      |                 |
+| --datastore-read-replica-conn-pool-read-healthcheck-interval      | amount of time between connection health checks in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-healthcheck-interval=30s` |
+| --datastore-read-replica-conn-pool-read-max-idletime              | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-idletime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime              | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-lifetime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime-jitter       | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) | `--datastore-read-replica-conn-pool-read-max-lifetime-jitter=6m` |
+| --datastore-read-replica-conn-pool-read-max-open                  | number of concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-open=20` |
+| --datastore-read-replica-conn-pool-read-min-open                  | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-min-open=20` |
 
 ## MySQL
 
@@ -272,6 +261,7 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 - Setup and operational complexity of running MySQL
 - Does not rely on any non-standard MySQL extensions
 - Compatible with managed MySQL services
+- Can be scaled out on read workloads using read replicas
 
 ### Developer Notes
 
@@ -286,6 +276,33 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 [go-mysql-driver]: https://github.com/go-sql-driver/mysql
 [mysql-executor]: https://github.com/authzed/spicedb/blob/main/internal/datastore/mysql/datastore.go#L317
 [mysql-mvcc]: https://en.wikipedia.org/wiki/Multiversion_concurrency_control
+
+### Read Replicas
+
+<Callout type="warning">
+Do not use a load balancer between SpiceDB and MySQL replicas because SpiceDB will not be able to maintain consistency guarantees.
+</Callout>
+
+SpiceDB supports MySQL read replicas and does it while retaining consistency guarantees.
+Typical use cases are:
+
+- scale read workloads/offload reads from the primary
+- deploy SpiceDB in other regions with primarily read workloads
+
+Read replicas are typically configured with asynchronous replication, which involves replication lag.
+That would be problematic to SpiceDB's ability to solve the new enemy problem but it addresses the challenge by checking if the revision has been replicated into the target replica.
+If missing, it will fall back to the primary.
+Compared to the Postgres implementation, MySQL support requires two roundtrips instead of one, which means it adds some extra latency overhead.
+
+All API consistency options will leverage replicas, but the ones that benefit the most are those that involve some level of staleness as it increases the odds a revision has replicated.
+`minimize_latency`, `at_least_as_fresh`, and `at_exact_snapshot` consistency modes have the highest chance of being redirected to a replica.
+
+SpiceDB does not support MySQL replicas behind a load-balancer: you may only list replica hosts individually.
+Failing to adhere to this would compromise consistency guarantees.
+When multiple host URIs are provided, they will be queried using round-robin.
+Please note that the maximum number of MySQL replica host URIs to list is 16.
+
+Read replicas are configured with the `--datastore-read-replica-*` family of flags.
 
 ### Configuration
 
@@ -312,6 +329,14 @@ ALTER ZONE default CONFIGURE ZONE USING gc.ttlseconds = 90000;
 | `datastore-revision-fuzzing-duration` | Sets a fuzzing window on all zookies/zedtokens                                      | `--datastore-revision-fuzzing-duration=50ms` |
 | `datastore-mysql-table-prefix string` | Prefix to add to the name of all SpiceDB database tables                            | `--datastore-mysql-table-prefix=spicedb`     |
 | `datastore-readonly`                  | Places the datastore into readonly mode                                             | `--datastore-readonly=true`                  |
+| `datastore-read-replica-conn-uri`     | Connection string used by datastores for read replicas; only supported for postgres and MySQL | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
+| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using aws-iam                      |                 |
+| --datastore-read-replica-conn-pool-read-healthcheck-interval      | amount of time between connection health checks in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-healthcheck-interval=30s` |
+| --datastore-read-replica-conn-pool-read-max-idletime              | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-idletime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime              | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-lifetime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime-jitter       | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) | `--datastore-read-replica-conn-pool-read-max-lifetime-jitter=6m` |
+| --datastore-read-replica-conn-pool-read-max-open                  | number of concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-open=20` |
+| --datastore-read-replica-conn-pool-read-min-open                  | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-min-open=20` |
 
 ## memdb
 

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -32,7 +32,7 @@ For more information, refer to the [Datastore Migration documentation](/spicedb/
 
 ## Read replicas for Postgres and MySQL
 
-SpiceDB can query read-only replicas of permissions data stored in Postgres and MySQL while maintaining consistency guarantees by detecting if a given revision has been replicated from the primary datastore before reading from the replica. 
+SpiceDB can query read-only replicas of permissions data stored in Postgres and MySQL while maintaining consistency guarantees by detecting if a given revision has been replicated from the primary datastore before reading from the replica.
 If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
 
 When using multiple replicas, the queried replica will be chosen in a round-robin fashion.
@@ -40,12 +40,13 @@ Please note that the maximum replica count is 16.
 
 Traffic using `minimize_latency` will benefit the most from using read replicas.
 
-#### PostgreSQL read replicas
+### PostgreSQL read replicas
 
-You can use a load balancer between PostgreSQL replicas and SpiceDB. When using a load balancer, please ensure that `ReadStrictMode` is enabled on your datastore. 
+You can use a load balancer between PostgreSQL replicas and SpiceDB.
+When using a load balancer, please ensure that `ReadStrictMode` is enabled on your datastore.
 If you are not using a load balancer, you can, alternatiely, list each hostname individually.
 
-#### MySQL read replicas
+### MySQL read replicas
 
 <Callout type="warning">
 Do not use a load balancer between SpiceDB and MySQL replicas because SpiceDB will not be able to maintain consistency guarantees.

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -65,9 +65,6 @@ database must be configured as its own replica to SpiceDB, which each URI given 
 | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using (%s)                      |                 |
 
-
-
-
 ## CockroachDB
 
 ### Usage Notes

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -41,7 +41,6 @@ This mode is useful for deploying replicas behind a load balancer than can trans
 To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one
 requested.
 
-Includes a test to return whether the replicated request successfully falls back to the primary datastore.
 
 ### Usage Notes
 

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -31,17 +31,23 @@ spicedb migrate head \
 For more information, refer to the [Datastore Migration documentation](/spicedb/concepts/datastore-migrations).
 
 ## Read replicas for Postgres and MySQL
-SpiceDB can reference read-only replicas of permissions data stored in Postgres and MySQL that respect consistency requirements by detecting if a given revision has been replicated from the primary datastore before reading from the replica. If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
 
-Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read. This mode is useful for deploying replicas behind a load balancer than can transparently handle these requests.
+SpiceDB can reference read-only replicas of permissions data stored in Postgres and MySQL that respect consistency requirements by detecting if a given revision has been replicated from the
+primary datastore before reading from the replica. If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
 
-To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one requested.
+Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read. 
+This mode is useful for deploying replicas behind a load balancer than can transparently handle these requests.
+To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one
+requested.
 
 Includes a test to return whether the replicated request successfully falls back to the primary datastore.
 
 ### Usage Notes
+
 - Maximum replica count is 16.
-- Note: be very careful when using this function. It is not safe to be sued without knowledge of underlying datastore and replicas. Replicas will be checked for the requested revision before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load balancer). That means each replica node in the database must be configured as its own replica to SpiceDB, which each URI given distinctly.
+- Note: be very careful when using this function. It is not safe to be sued without knowledge of underlying datastore and replicas. Replicas will be checked for the requested revision 
+before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load balancer). That means each replica node in the
+database must be configured as its own replica to SpiceDB, which each URI given distinctly.
 - Calls using strict read mode must reference replicas with strict mode enabled to ensure the query will fail with a revision unavailable error if the specified revision is not available.
 
 ### Configuration

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -33,9 +33,10 @@ For more information, refer to the [Datastore Migration documentation](/spicedb/
 ## Read replicas for Postgres and MySQL
 
 SpiceDB can reference read-only replicas of permissions data stored in Postgres and MySQL that respect consistency requirements by detecting if a given revision has been replicated from the
-primary datastore before reading from the replica. If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
+primary datastore before reading from the replica.
+If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
 
-Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read. 
+Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read.
 This mode is useful for deploying replicas behind a load balancer than can transparently handle these requests.
 To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one
 requested.
@@ -45,9 +46,11 @@ Includes a test to return whether the replicated request successfully falls back
 ### Usage Notes
 
 - Maximum replica count is 16.
-- Note: be very careful when using this function. It is not safe to be sued without knowledge of underlying datastore and replicas. Replicas will be checked for the requested revision 
-before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load balancer). That means each replica node in the
-database must be configured as its own replica to SpiceDB, which each URI given distinctly.
+- Note: be very careful when using this function.
+It is not safe to be used without knowledge of underlying datastore and replicas.
+Replicas will be checked for the requested revision before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load
+balancer).
+That means each replica node in the database must be configured as its own replica to SpiceDB, which each URI given distinctly.
 - Calls using strict read mode must reference replicas with strict mode enabled to ensure the query will fail with a revision unavailable error if the specified revision is not available.
 
 ### Configuration

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -43,7 +43,6 @@ Traffic using `minimize_latency` will benefit the most from using read replicas.
 ### PostgreSQL read replicas
 
 You can use a load balancer between PostgreSQL replicas and SpiceDB.
-When using a load balancer, please ensure that `ReadStrictMode` is enabled on your datastore.
 If you are not using a load balancer, you can, alternatiely, list each hostname individually.
 
 ### MySQL read replicas

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -32,25 +32,25 @@ For more information, refer to the [Datastore Migration documentation](/spicedb/
 
 ## Read replicas for Postgres and MySQL
 
-SpiceDB can reference read-only replicas of permissions data stored in Postgres and MySQL that respect consistency requirements by detecting if a given revision has been replicated from the
-primary datastore before reading from the replica.
+SpiceDB can query read-only replicas of permissions data stored in Postgres and MySQL while maintaining consistency guarantees by detecting if a given revision has been replicated from the primary datastore before reading from the replica. 
 If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
 
-Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read.
-This mode is useful for deploying replicas behind a load balancer than can transparently handle these requests.
-To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one
-requested.
+When using multiple replicas, the queried replica will be chosen in a round-robin fashion.
+Please note that the maximum replica count is 16.
 
+Traffic using `minimize_latency` will benefit the most from using read replicas.
 
-### Usage Notes
+#### PostgreSQL read replicas
 
-- Maximum replica count is 16.
-- Note: be very careful when using this function.
-It is not safe to be used without knowledge of underlying datastore and replicas.
-Replicas will be checked for the requested revision before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load
-balancer).
-That means each replica node in the database must be configured as its own replica to SpiceDB, which each URI given distinctly.
-- Calls using strict read mode must reference replicas with strict mode enabled to ensure the query will fail with a revision unavailable error if the specified revision is not available.
+You can use a load balancer between PostgreSQL replicas and SpiceDB. When using a load balancer, please ensure that `ReadStrictMode` is enabled on your datastore. 
+If you are not using a load balancer, you can, alternatiely, list each hostname individually.
+
+#### MySQL read replicas
+
+<Callout type="warning">
+Do not use a load balancer between SpiceDB and MySQL replicas because SpiceDB will not be able to maintain consistency guarantees.
+</Callout>
+When using MySQL replicas, each hostname must be listed individually.
 
 ### Configuration
 
@@ -65,7 +65,7 @@ That means each replica node in the database must be configured as its own repli
 
 | Parameter            | Description                               | Example                                                                                   |
 | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using (%s)                      |                 |
+| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using aws-iam                      |                 |
 
 ## CockroachDB
 

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -60,7 +60,7 @@ When using MySQL replicas, each hostname must be listed individually.
 | Parameter            | Description                               | Example                                                                                   |
 | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `datastore-engine`   | the datastore engine                      | `--datastore-engine=postgres`                                                          |
-| `datastore-read-replica-conn-uri` | Connection string used by remote datastores for read replicas; only supported for postgres and mysql | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
+| `datastore-read-replica-conn-uri` | Connection string used by datastores for read replicas; only supported for postgres and MySQL | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
 
 #### Optional Parameters
 

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -30,6 +30,38 @@ spicedb migrate head \
 
 For more information, refer to the [Datastore Migration documentation](/spicedb/concepts/datastore-migrations).
 
+## Read replicas for Postgres and MySQL
+SpiceDB can reference read-only replicas of permissions data stored in Postgres and MySQL that respect consistency requirements by detecting if a given revision has been replicated from the primary datastore before reading from the replica. If the requested revision is not found in the replica, the request will be redirected to the primary datastore.
+
+Strict read mode (available for Postgres only) does not check replicas for requested revisions before reading from them; instead, a revision check is inserted into the SQL for each read. This mode is useful for deploying replicas behind a load balancer than can transparently handle these requests.
+
+To reduce overhead of using read replicas, enable caching on CheckRevision calls to avoid checking the requested revision if the last checked revision is at least as fresh as the one requested.
+
+Includes a test to return whether the replicated request successfully falls back to the primary datastore.
+
+### Usage Notes
+- Maximum replica count is 16.
+- Note: be very careful when using this function. It is not safe to be sued without knowledge of underlying datastore and replicas. Replicas will be checked for the requested revision before reading from them, which means that the read pool for the replicas must point to a stable instance of the datastore (not a load balancer). That means each replica node in the database must be configured as its own replica to SpiceDB, which each URI given distinctly.
+- Calls using strict read mode must reference replicas with strict mode enabled to ensure the query will fail with a revision unavailable error if the specified revision is not available.
+
+### Configuration
+
+#### Required Parameters
+
+| Parameter            | Description                               | Example                                                                                   |
+| -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `datastore-engine`   | the datastore engine                      | `--datastore-engine=postgres`                                                          |
+| `datastore-read-replica-conn-uri` | Connection string used by remote datastores for read replicas; only supported for postgres and mysql | `--datastore-read-replica-conn-uri="postgres://postgres:password@localhost:5432/spicedb\"` |
+
+#### Optional Parameters
+
+| Parameter            | Description                               | Example                                                                                   |
+| -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using (%s)                      |                 |
+
+
+
+
 ## CockroachDB
 
 ### Usage Notes

--- a/pages/spicedb/concepts/datastores.mdx
+++ b/pages/spicedb/concepts/datastores.mdx
@@ -66,6 +66,12 @@ When using MySQL replicas, each hostname must be listed individually.
 | Parameter            | Description                               | Example                                                                                   |
 | -------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `—datastore-read-replica-credentials-provider-name`               | Retrieve datastore credentials dynamically using aws-iam                      |                 |
+| --datastore-read-replica-conn-pool-read-healthcheck-interval | amount of time between connection health checks in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-healthcheck-interval=30s` |
+| --datastore-read-replica-conn-pool-read-max-idletime | maximum amount of time a connection can idle in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-idletime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime | maximum amount of time a connection can live in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-lifetime=30m` |
+| --datastore-read-replica-conn-pool-read-max-lifetime-jitter | waits rand(0, jitter) after a connection is open for max lifetime to actually close the connection to a read replica(default: 20% of max lifetime) | `--datastore-read-replica-conn-pool-read-max-lifetime-jitter=6m` |
+| --datastore-read-replica-conn-pool-read-max-open | number of concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-max-open=20` |
+| --datastore-read-replica-conn-pool-read-min-open | number of minimum concurrent connections open in a read-only replica datastore's connection pool | `--datastore-read-replica-conn-pool-read-min-open=20` |
 
 ## CockroachDB
 


### PR DESCRIPTION
this PR adds documentation around MySQL and Postgres replica support in SpiceDB