### PR TITLE
Fix caveats.mdx CIDR definition

### DIFF
--- a/pages/spicedb/concepts/caveats.mdx
+++ b/pages/spicedb/concepts/caveats.mdx
@@ -103,7 +103,7 @@ WriteRelationshipsRequest {
         Subject: …,
         OptionalCaveat: {
            CaveatName: "ip_allowlist",
-           Context: structpb{ "cidr": "1.2.3.0" }
+           Context: structpb{ "cidr": "1.2.3.0/24" }
         }
       }
     }
@@ -189,7 +189,7 @@ WriteRelationshipsRequest {
         },
         OptionalCaveat: {
            CaveatName: "has_valid_ip",
-           Context: structpb{ "allowed_range": "10.20.30.0" }
+           Context: structpb{ "allowed_range": "10.20.30.0/24" }
         }
       }
     }


### PR DESCRIPTION
Caveat definition with a cidr like this throws an error in the playground: "evaluation error for caveat has_valid_ip: invalid CIDR string: `10.20.30.0`"

Needs to have the /24 appendage