### PR TITLE
Update deploying-spicedb-operator.mdx

### DIFF
--- a/pages/spicedb/ops/deploying-spicedb-operator.mdx
+++ b/pages/spicedb/ops/deploying-spicedb-operator.mdx
@@ -104,7 +104,7 @@ If you don't already have zed installed, you can follow [this guide][install-zed
 For zed to connect to SpiceDB, we'll first have to create an insecure context named `local` for connecting to our locally forwarded port:
 
 ```sh
-zed context set local localhost:50051 "somerandomkeyhere" --insecure
+zed context set local localhost:50051 "averysecretpresharedkey" --insecure
 ```
 
 With our context set, we're free to make requests to our new, empty SpiceDB deployment:


### PR DESCRIPTION
I'm not 100% sure about this but I think the Secret key should match what is set in the Cluster manifest from earlier? 

Using the key currently mentioned in the doc, I see this error: 
```
ERR terminated with errors error="rpc error: code = PermissionDenied desc = invalid preshared key: invalid token"