### PR TITLE
Update protecting-a-blog.mdx

### DIFF
--- a/pages/spicedb/getting-started/protecting-a-blog.mdx
+++ b/pages/spicedb/getting-started/protecting-a-blog.mdx
@@ -129,7 +129,8 @@ definition post {
     permission read = reader + writer
     permission write = writer
 }
-EOF)
+EOF
+)
 ```
 
 </Tabs.Tab>


### PR DESCRIPTION
Need someone to test this out but copy-pasting this block of code confuses the terminal and opens up the heredoc CLI as it thinks it's not terminated correctly. Essentially I see this:

```
cmdsubst heredoc>
```

Was able to fix this by terminating the EOF in the next line.  I'm using zsh on mac.