### PR TITLE
Update deploying-spicedb-on-eks.mdx

### DIFF
--- a/pages/spicedb/ops/deploying-spicedb-on-eks.mdx
+++ b/pages/spicedb/ops/deploying-spicedb-on-eks.mdx
@@ -315,7 +315,7 @@ EOF
 Write a relationship:
 
 ```yaml
-zed relationship create doc:1 writer user:emilia
+zed relationship create doc:1 owner user:emilia
 ```
 
 Check a permission:


### PR DESCRIPTION
minor change - the doc definition has only owner and no writer.