### PR TITLE
Update materialize doc with simpler SQL

### DIFF
--- a/pages/authzed/concepts/authzed-materialize.mdx
+++ b/pages/authzed/concepts/authzed-materialize.mdx
@@ -168,7 +168,7 @@ SELECT d.id FROM documents d
   WHERE 
    u.name = 'evan' AND 
    m2s.member_type = 'user' AND 
-   m2s.member_relation = '...' AND ((
+   m2s.member_relation = '' AND ((
       s2s.parent_type = 'document' AND
       s2s.parent_relation='view'
     ) OR (
@@ -192,7 +192,7 @@ SELECT d.id FROM documents d
   WHERE 
    u.name = 'victor' AND 
    m2s.member_type = 'user' AND 
-   m2s.member_relation = '...' AND ((
+   m2s.member_relation = '' AND ((
       s2s.parent_type = 'document' AND
       s2s.parent_relation='view'
     ) OR (

--- a/pages/authzed/concepts/authzed-materialize.mdx
+++ b/pages/authzed/concepts/authzed-materialize.mdx
@@ -95,7 +95,7 @@ resource#edit@user
 
 ### Relational Database
 
-You can find [here](https://dbfiddle.uk/OP5GwjoG) a runnable version of these examples
+You can find a runnable version of these examples [here](https://dbfiddle.uk/dX10Cu3Z).
 
 These are tables you likely already have in your database
 
@@ -162,22 +162,19 @@ Find all documents `evan` can `view:`
 
 ```sql
 SELECT d.id FROM documents d
-  INNER JOIN set_to_set s2s ON d.id = s2s.parent_id
-  INNER JOIN member_to_set m2s ON m2s.set_id = s2s.child_id AND m2s.set_type = s2s.child_type AND m2s.set_relation = s2s.child_relation
+  LEFT JOIN set_to_set s2s ON d.id = s2s.parent_id
+  INNER JOIN member_to_set m2s ON (m2s.set_id = s2s.child_id AND m2s.set_type = s2s.child_type AND m2s.set_relation = s2s.child_relation) OR (d.id = m2s.set_id )
   INNER JOIN users u ON u.id = m2s.member_id
-  WHERE u.name = 'evan' 
-    AND m2s.member_type = 'user' 
-    AND m2s.member_relation = '' 
-    AND s2s.parent_type = 'document' 
-    AND s2s.parent_relation='view'
-UNION
-SELECT d.id FROM documents d
-  INNER JOIN member_to_set m2s ON d.id = m2s.set_id
-  INNER JOIN users u ON u.id = m2s.member_id
-  WHERE u.name = 'evan' 
-    AND m2s.member_type = 'user' 
-    AND m2s.member_relation = '' 
-    AND m2s.set_type = 'document' AND m2s.set_relation = 'view';
+  WHERE 
+   u.name = 'evan' AND 
+   m2s.member_type = 'user' AND 
+   m2s.member_relation = '...' AND ((
+      s2s.parent_type = 'document' AND
+      s2s.parent_relation='view'
+    ) OR (
+      m2s.set_type = 'document' AND
+      m2s.set_relation = 'view'
+    ));
 ```
 
 | id |
@@ -189,22 +186,19 @@ The same query, by changing only the username, will find all documents `victor` 
 
 ```sql
 SELECT d.id FROM documents d
-  INNER JOIN set_to_set s2s ON d.id = s2s.parent_id
-  INNER JOIN member_to_set m2s ON m2s.set_id = s2s.child_id AND m2s.set_type = s2s.child_type AND m2s.set_relation = s2s.child_relation
+  LEFT JOIN set_to_set s2s ON d.id = s2s.parent_id
+  INNER JOIN member_to_set m2s ON (m2s.set_id = s2s.child_id AND m2s.set_type = s2s.child_type AND m2s.set_relation = s2s.child_relation) OR (d.id = m2s.set_id )
   INNER JOIN users u ON u.id = m2s.member_id
-  WHERE u.name = 'victor' 
-    AND m2s.member_type = 'user' 
-    AND m2s.member_relation = '' 
-    AND s2s.parent_type = 'document' 
-    AND s2s.parent_relation='view'
-UNION
-SELECT d.id FROM documents d
-  INNER JOIN member_to_set m2s ON d.id = m2s.set_id
-  INNER JOIN users u ON u.id = m2s.member_id
-  WHERE u.name = 'victor' 
-    AND m2s.member_type = 'user' 
-    AND m2s.member_relation = '' 
-    AND m2s.set_type = 'document' AND m2s.set_relation = 'view';
+  WHERE 
+   u.name = 'victor' AND 
+   m2s.member_type = 'user' AND 
+   m2s.member_relation = '...' AND ((
+      s2s.parent_type = 'document' AND
+      s2s.parent_relation='view'
+    ) OR (
+      m2s.set_type = 'document' AND
+      m2s.set_relation = 'view'
+    ));
 ```
 
 | id |

--- a/pages/authzed/concepts/authzed-materialize.mdx
+++ b/pages/authzed/concepts/authzed-materialize.mdx
@@ -237,7 +237,7 @@ INSERT INTO set_to_document_view (child_set, document_id)
          ('group:shared#member', '456');
 ```
 
-Note that an extra entry (`document:123#view`, `123`) was added to simplify the join side (avoiding the union in the previous example).
+Note that an extra entry (`document:123#view`, `123`) was added to simplify the join side (avoiding the `left join` in the previous example).
 The queries are a bit simpler, though they can't be used to answer any permission check other than `document#view@user`.
 
 Find all documents `evan` can `view`:


### PR DESCRIPTION
I think a single `select` comes off as simpler to grok right now. 

The motivation here was that when I was grafting materialize onto an existing project for a demo, I found the ORM that project used made it much easier to build non-union queries. 

My only concern with this example is that non-inner joins are much less common and might be confusing in their own right - might be worth coming back to this and expanding on the reason (in this case it's because we don't want to discard rows from the join if they don't have a `set_to_set` match, since they might have a "direct" `member_to_set` match.)