### PR TITLE
Update debian install instructions

### DIFF
--- a/pages/spicedb/getting-started/install/debian.mdx
+++ b/pages/spicedb/getting-started/install/debian.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Installing SpiceDB on Ubuntu or Debian
 
 This document outlines how to install SpiceDB for systems running [Debian-like Linux distributions][debianlike].
@@ -13,24 +15,36 @@ Visit the doc on [Installing SpiceDB on RHEL/Centos][rhel]
 
 ## Installing SpiceDB using apt-get
 
-Before installing SpiceDB, you must first install the following dependencies:
+First, download the public signing key for the repository:
 
 ```sh
-sudo apt update && sudo apt install -y curl ca-certificates gpg
+# In releases older than Debian 12 and Ubuntu 22.04, the folder `/etc/apt/keyrings` does not exist by default, and it should be created before the curl command.
+# sudo mkdir -p -m 755 /etc/apt/keyrings
+
+curl -sS https://pkg.authzed.com/apt/gpg.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/spicedb.gpg
 ```
 
-These dependencies are used to verify and trust the official SpiceDB Debian repository.
-We'll do that by running the following commands:
+Then add the list file for the repository:
 
 ```sh
-curl https://pkg.authzed.com/apt/gpg.key | sudo apt-key add -
-sudo sh -c 'echo "deb https://pkg.authzed.com/apt/ * *" > /etc/apt/sources.list.d/authzed.list'
+echo "deb [signed-by=/etc/apt/keyrings/spicedb.gpg] https://pkg.authzed.com/apt/ * *"  | sudo tee /etc/apt/sources.list.d/authzed.list
+sudo chmod 644 /etc/apt/sources.list.d/authzed.list  # helps tools such as command-not-found to work correctly
+```
+
+Alternatively, if you want to use the new `deb822`-style `authzed.sources` format, put the following in `/etc/apt/sources.list.d/authzed.sources`:
+
+```
+Types: deb
+URIs: https://pkg.authzed.com/apt/
+Suites: *
+Components: *
+Signed-By: /etc/apt/keyrings/spicedb.gpg
+```
+
+Once the you've defined the sources and updated your apt cache, it can be installed just like any other package:
+
+```sh
 sudo apt update
-```
-
-Once the apt has updated with our newly added source for SpiceDB packages, it can be installed just like any other package:
-
-```sh
 sudo apt install -y spicedb
 ```
 


### PR DESCRIPTION
Fixes #293 

## Description

I went to use these instructions to get a local binary of `spicedb` so that I could test something with the VSCode extension. I noticed that our instructions still use `apt-key add`, which [has been deprecated](https://medium.com/@glegoux/ubuntu-22-04-jammy-jellyfish-apt-key-is-deprecated-2dbbee8aec84). This updates to the new method, which cribs from the [kubernetes directions](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management).

## Changes
* Update documentation around debian installation
## Testing
Review.