### PR TITLE
Update AWS private networking instructions

### DIFF
--- a/pages/authzed/guides/setting-up-private-networking.mdx
+++ b/pages/authzed/guides/setting-up-private-networking.mdx
@@ -31,7 +31,7 @@ Navigate to `VPC` → `Endpoints` → `Create Endpoint` and input the following 
 | Option               | Selection            |
 | :-------------------:| :-------------------:|
 | Name tag         | Choose whatever you want |
-| Service category   | Select “Other endpoint services” |
+| Service category   | Select “Endpoint services that use NLBs and GWLBs” |
 | Service name       | Enter the "service name" provided to you by the AuthZed team |
 | VPC                | Choose the VPC from where you will deploy your SpiceDB client. DNS resolution for your SpiceDB cluster endpoint address will only be available from this VPC. |
 | Subnets            | You can deploy your VPC endpoint in one subnet per AZ. We recommend choosing all AZs where SpiceDB clients will exist. |


### PR DESCRIPTION
AWS Console has changed its options when creating new VPC Endpoints.  Updated to correct option here.

![image](https://github.com/user-attachments/assets/2ce07753-b9fa-4e35-9692-4a3662f4e1af)
