### PR TITLE
Use literal block format for example validation

### DIFF
--- a/pages/spicedb/modeling/validation-testing-debugging.mdx
+++ b/pages/spicedb/modeling/validation-testing-debugging.mdx
@@ -186,13 +186,13 @@ zed validate schema-and-validations.yaml
 Validation files take this form:
 
 ```yaml
-schema: >-
+schema: |-
   // schema goes here
 # -- OR --
 schemaFile: "./path/to/schema.zed"
 
 # Note that relations are a single heredoc string rather than a yaml list
-relationships: >-
+relationships: |-
   object:foo#relation@subject:bar
   object:baz#relation@subject:qux
 


### PR DESCRIPTION
## Description
A user on discord pointed out that the example file doesn't work as written. This is because we were using a [folding block scalar](https://yaml-multiline.info/#block-scalars) instead of a literal, which meant that it was turning newlines into spaces and causing the relation parsing to fail. We need to preserve newlines, which the literal does.

## Changes
* Use literal block scalar

## Testing
Review. Copy out this block and run `zed validate` against it and see that it succeeds.