### PR TITLE
Fix discord invitation link

### DIFF
--- a/pages/authzed/guides/picking-a-product.mdx
+++ b/pages/authzed/guides/picking-a-product.mdx
@@ -120,7 +120,7 @@ For bug reports, feature requests, and development discussion, [GitHub Issues] a
   Please be respectful and read over the community [Code of Conduct] before interacting.
 </Callout>
 
-[discord]: https://discord.gg/spicedb
+[discord]: https://authzed.com/discord
 [github discussions]: https://github.com/orgs/authzed/discussions/categories/q-a
 [github issues]: https://github.com/authzed/spicedb/issues
 [Code of Conduct]: https://github.com/authzed/spicedb/blob/main/CODE-OF-CONDUCT.md


### PR DESCRIPTION
Fix discord invitation link to use https://authzed.com/discord specified on https://authzed.com/products/authzed-support