### PR TITLE
chore(docs): simplify FGAM token generation

### DIFF
--- a/pages/authzed/concepts/restricted-api-access.mdx
+++ b/pages/authzed/concepts/restricted-api-access.mdx
@@ -251,18 +251,19 @@ If you want to apply a configuration to an existing SpiceDB cluster without down
    ```sh
    # Generate your secret (substitute your preferred method for generating a cryptographically-secure random string here)
    # This will be a part of the token
-   base64 < /dev/random | head -c64
+   SECRET="$(base64 < /dev/random | head -c64)"; echo "$SECRET"
    # g2l2/YjC3jFg6FdV080qiqBPvCrlLuc9GcHutgHF4WhVjsg7+AvlqLmoCrJEC68t
 
    # Hash that secret using sha256sum
    # This will go in your FGAM configuration as the token hash
    # NOTE: truncate the trailing spaces and "-". You just want the alphanum characters.
-   echo -n "g2l2/YjC3jFg6FdV080qiqBPvCrlLuc9GcHutgHF4WhVjsg7+AvlqLmoCrJEC68t" | sha256sum
-   # 1d619ac2f5013845c5f2df93add92fc87e88ca6c57d19a77d1b189663f1ff5b0  -
+   HASH="$(echo -n "$SECRET" | sha256sum | cut -d" " -f1)"; echo "$HASH"
+   # 1d619ac2f5013845c5f2df93add92fc87e88ca6c57d19a77d1b189663f1ff5b0
    
-   # Add the prefix to create the token that you'll supply to your client
-   echo "sdbst_h256_g2l2/YjC3jFg6FdV080qiqBPvCrlLuc9GcHutgHF4WhVjsg7+AvlqLmoCrJEC68t"
-   # sdbst_h256_g2l2/YjC3jFg6FdV080qiqBPvCrlLuc9GcHutgHF4WhVjsg7+AvlqLmoCrJEC68t
+   # Add the prefix "sdbst_h256_" to create the token that you'll supply to your client
+   printf "token: sdbst_h256_%s\nhash: %s\n" "$SECRET" "$HASH"
+   # token: sdbst_h256_g2l2/YjC3jFg6FdV080qiqBPvCrlLuc9GcHutgHF4WhVjsg7+AvlqLmoCrJEC68t
+   # hash: 1d619ac2f5013845c5f2df93add92fc87e88ca6c57d19a77d1b189663f1ff5b0
    ```
 
 2. Prepare the FGAM configuration YAML.


### PR DESCRIPTION
This commit simplifies the recommended code for generating FGMA tokens
so that the entire code-block can be copy-pasted and work. Right now, if
you copy-pasted the code you would actually end up always using the
hard-coded token from the example rather than using a freshly-generated
value.

Signed-off-by: squat <lserven@gmail.com>
