### PR TITLE
Improve local development credential documentation

### DIFF
--- a/app/spicedb/concepts/commands/page.mdx
+++ b/app/spicedb/concepts/commands/page.mdx
@@ -27,13 +27,12 @@ A database that stores and computes permissions
 
 ### Children commands
 
-- [spicedb datastore](#reference-spicedb-datastore)	 - datastore operations
-- [spicedb lsp](#reference-spicedb-lsp)	 - serve language server protocol
-- [spicedb man](#reference-spicedb-man)	 - Generate man page
-- [spicedb serve](#reference-spicedb-serve)	 - serve the permissions database
-- [spicedb serve-testing](#reference-spicedb-serve-testing)	 - test server with an in-memory datastore
-- [spicedb version](#reference-spicedb-version)	 - displays the version of SpiceDB
-
+- [spicedb datastore](#reference-spicedb-datastore) - datastore operations
+- [spicedb lsp](#reference-spicedb-lsp) - serve language server protocol
+- [spicedb man](#reference-spicedb-man) - Generate man page
+- [spicedb serve](#reference-spicedb-serve) - serve the permissions database
+- [spicedb serve-testing](#reference-spicedb-serve-testing) - test server with an in-memory datastore
+- [spicedb version](#reference-spicedb-version) - displays the version of SpiceDB
 
 ## Reference: `spicedb datastore`
 
@@ -49,11 +48,10 @@ Operations against the configured datastore
 
 ### Children commands
 
-- [spicedb datastore gc](#reference-spicedb-datastore-gc)	 - executes garbage collection
-- [spicedb datastore head](#reference-spicedb-datastore-head)	 - compute the head (latest) database migration revision available
-- [spicedb datastore migrate](#reference-spicedb-datastore-migrate)	 - execute datastore schema migrations
-- [spicedb datastore repair](#reference-spicedb-datastore-repair)	 - executes datastore repair
-
+- [spicedb datastore gc](#reference-spicedb-datastore-gc) - executes garbage collection
+- [spicedb datastore head](#reference-spicedb-datastore-head) - compute the head (latest) database migration revision available
+- [spicedb datastore migrate](#reference-spicedb-datastore-migrate) - execute datastore schema migrations
+- [spicedb datastore repair](#reference-spicedb-datastore-repair) - executes datastore repair
 
 ## Reference: `spicedb datastore gc`
 
@@ -148,8 +146,6 @@ spicedb datastore gc [flags]
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
 
-
-
 ## Reference: `spicedb datastore head`
 
 compute the head (latest) database migration revision available
@@ -180,8 +176,6 @@ spicedb datastore head [flags]
       --log-level string     verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
-
-
 
 ## Reference: `spicedb datastore migrate`
 
@@ -221,8 +215,6 @@ spicedb datastore migrate [revision] [flags]
       --log-level string     verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
-
-
 
 ## Reference: `spicedb datastore repair`
 
@@ -317,8 +309,6 @@ spicedb datastore repair [flags]
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
 
-
-
 ## Reference: `spicedb lsp`
 
 serve language server protocol
@@ -342,19 +332,16 @@ spicedb lsp [flags]
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
 
-
-
 ## Reference: `spicedb man`
 
 Generate a man page for SpiceDB.
- The output can be redirected to a file and installed to the system:
+The output can be redirected to a file and installed to the system:
 
 ```
   spicedb man > spicedb.1
   sudo mv spicedb.1 /usr/share/man/man1/
   sudo mandb  # Update man page database
 ```
-
 
 ```
 spicedb man
@@ -367,8 +354,6 @@ spicedb man
       --log-level string     verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
-
-
 
 ## Reference: `spicedb serve`
 
@@ -558,8 +543,6 @@ spicedb serve [flags]
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
 
-
-
 ## Reference: `spicedb serve-testing`
 
 An in-memory spicedb server which serves completely isolated datastores per client-supplied auth token used.
@@ -621,8 +604,6 @@ spicedb serve-testing [flags]
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
 
-
-
 ## Reference: `spicedb version`
 
 displays the version of SpiceDB
@@ -644,6 +625,3 @@ spicedb version [flags]
       --log-level string     verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
       --skip-release-check   if true, skips checking for new SpiceDB releases
 ```
-
-
-

--- a/app/spicedb/getting-started/client-libraries/page.mdx
+++ b/app/spicedb/getting-started/client-libraries/page.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from "nextra/components";
+
 # Official Client Libraries
 
 SpiceDB is primarily accessed by a [gRPC] API and thus client libraries can be generated for any programming language.
@@ -9,7 +11,7 @@ AuthZed builds and maintains gRPC client libraries for the following languages:
 - [Python](https://github.com/authzed/authzed-py)
 - [Ruby](https://github.com/authzed/authzed-rb)
 - [Java](https://github.com/authzed/authzed-java)
-- [Dotnet](https://github.com/authzed/authzed-dotnet)
+- [.NET](https://github.com/authzed/authzed-dotnet)
 
 Because the above libraries are generated from protobuf definitions in our [API repo],
 the primary documentation for the gRPC API is in the [buf documentation] for SpiceDB's services.
@@ -20,27 +22,43 @@ Additionally, there are `example` directories in the client libraries that provi
 
 When developing locally, you'll need to configure your client based on how SpiceDB is running.
 
-### Without TLS (most common)
+### SpiceDB running without TLS (most common)
 
 If SpiceDB is started without TLS (using `--grpc-no-tls`), use insecure plaintext credentials:
 
-- **Node.js**: `v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS`
-- **Python**: `insecure_bearer_token_credentials()`
-- **Go**: `grpcutil.WithInsecureBearerToken()` and `grpc.WithTransportCredentials(insecure.NewCredentials())`
-- **Ruby**: `credentials: :this_channel_is_insecure`
-- **Java**: `.usePlaintext()`
-- **Dotnet**: `ChannelCredentials.Insecure` with `UnsafeUseInsecureChannelCallCredentials = true` (also requires `AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true)`)
+<Tabs items={["Node", "Go", "Python", "Ruby", "Java", ".NET"]}>
+  <Tabs.Tab>`v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS`</Tabs.Tab>
+  <Tabs.Tab>
+    `grpcutil.WithInsecureBearerToken()` and
+    `grpc.WithTransportCredentials(insecure.NewCredentials())`
+  </Tabs.Tab>
+  <Tabs.Tab>`insecure_bearer_token_credentials()`</Tabs.Tab>
+  <Tabs.Tab>`credentials: :this_channel_is_insecure`</Tabs.Tab>
+  <Tabs.Tab>`.usePlaintext()`</Tabs.Tab>
+  <Tabs.Tab>
+    `ChannelCredentials.Insecure` with `UnsafeUseInsecureChannelCallCredentials
+    = true` (also requires
+    `AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport",
+    true)`)
+  </Tabs.Tab>
+</Tabs>
 
 This applies to localhost, Docker, OrbStack, and other local environments running without TLS.
 
-### With TLS using self-signed certificates
+### SpiceDB running with TLS using self-signed certificates
 
 If SpiceDB is running with TLS but using a self-signed or untrusted certificate:
 
-- **Node.js**: `v1.ClientSecurity.INSECURE_LOCALHOST_ALLOWED` (allows localhost connections without CA verification)
-- **Go**: Load the self-signed CA explicitly with `grpcutil.WithCustomCerts()` or use `grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))` for localhost only (not recommended for production)
+<Tabs items={['Node', 'Go']}>
+    <Tabs.Tab>
+        `v1.ClientSecurity.INSECURE_LOCALHOST_ALLOWED` (allows localhost connections without CA verification)
+    </Tabs.Tab>
+    <Tabs.Tab>
+        Load the self-signed CA explicitly with `grpcutil.WithCustomCerts()` or use `grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))` for localhost only (not recommended for production)
+    </Tabs.Tab>
+</Tabs>
 
-See the [Protecting a Blog Application](./protecting-a-blog#checking-permissions) guide for examples.
+See the [Protecting a Blog Application](./protecting-a-blog#checking-permissions) tutorial for examples.
 
 ## HTTP Clients
 

--- a/app/spicedb/getting-started/installing-zed/page.mdx
+++ b/app/spicedb/getting-started/installing-zed/page.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout } from "nextra/components";
 
 # Installing Zed
 
@@ -123,7 +123,6 @@ You can find more commands for tasks such as testing, linting in the repository'
 
 [CONTRIBUTING.md]: https://github.com/authzed/zed/blob/main/CONTRIBUTING.md
 
-
 ## Reference: `zed`
 
 A command-line client for managing SpiceDB clusters.
@@ -161,17 +160,16 @@ zed permission check --explain document:firstdoc writer user:emilia
 
 ### Children commands
 
-- [zed backup](#reference-zed-backup)	 - Create, restore, and inspect permissions system backups
-- [zed context](#reference-zed-context)	 - Manage configurations for connecting to SpiceDB deployments
-- [zed import](#reference-zed-import)	 - Imports schema and relationships from a file or url
-- [zed mcp](#reference-zed-mcp)	 - MCP (Model Context Protocol) server commands
-- [zed permission](#reference-zed-permission)	 - Query the permissions in a permissions system
-- [zed relationship](#reference-zed-relationship)	 - Query and mutate the relationships in a permissions system
-- [zed schema](#reference-zed-schema)	 - Manage schema for a permissions system
-- [zed use](#reference-zed-use)	 - Alias for `zed context use`
-- [zed validate](#reference-zed-validate)	 - Validates the given validation file (.yaml, .zaml) or schema file (.zed)
-- [zed version](#reference-zed-version)	 - Display zed and SpiceDB version information
-
+- [zed backup](#reference-zed-backup) - Create, restore, and inspect permissions system backups
+- [zed context](#reference-zed-context) - Manage configurations for connecting to SpiceDB deployments
+- [zed import](#reference-zed-import) - Imports schema and relationships from a file or url
+- [zed mcp](#reference-zed-mcp) - MCP (Model Context Protocol) server commands
+- [zed permission](#reference-zed-permission) - Query the permissions in a permissions system
+- [zed relationship](#reference-zed-relationship) - Query and mutate the relationships in a permissions system
+- [zed schema](#reference-zed-schema) - Manage schema for a permissions system
+- [zed use](#reference-zed-use) - Alias for `zed context use`
+- [zed validate](#reference-zed-validate) - Validates the given validation file (.yaml, .zaml) or schema file (.zed)
+- [zed version](#reference-zed-version) - Display zed and SpiceDB version information
 
 ## Reference: `zed backup`
 
@@ -210,13 +208,12 @@ zed backup <filename> [flags]
 
 ### Children commands
 
-- [zed backup create](#reference-zed-backup-create)	 - Backup a permission system to a file
-- [zed backup parse-relationships](#reference-zed-backup-parse-relationships)	 - Extract the relationships from a backup file
-- [zed backup parse-revision](#reference-zed-backup-parse-revision)	 - Extract the revision from a backup file
-- [zed backup parse-schema](#reference-zed-backup-parse-schema)	 - Extract the schema from a backup file
-- [zed backup redact](#reference-zed-backup-redact)	 - Redact a backup file to remove sensitive information
-- [zed backup restore](#reference-zed-backup-restore)	 - Restore a permission system from a file
-
+- [zed backup create](#reference-zed-backup-create) - Backup a permission system to a file
+- [zed backup parse-relationships](#reference-zed-backup-parse-relationships) - Extract the relationships from a backup file
+- [zed backup parse-revision](#reference-zed-backup-parse-revision) - Extract the revision from a backup file
+- [zed backup parse-schema](#reference-zed-backup-parse-schema) - Extract the schema from a backup file
+- [zed backup redact](#reference-zed-backup-redact) - Redact a backup file to remove sensitive information
+- [zed backup restore](#reference-zed-backup-restore) - Restore a permission system from a file
 
 ## Reference: `zed backup create`
 
@@ -253,8 +250,6 @@ zed backup create <filename> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed backup parse-relationships`
 
 Extract the relationships from a backup file
@@ -288,8 +283,6 @@ zed backup parse-relationships <filename> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed backup parse-revision`
 
 Extract the revision from a backup file
@@ -316,8 +309,6 @@ zed backup parse-revision <filename>
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed backup parse-schema`
 
@@ -352,8 +343,6 @@ zed backup parse-schema <filename> [flags]
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed backup redact`
 
@@ -390,8 +379,6 @@ zed backup redact <filename> [flags]
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed backup restore`
 
@@ -432,8 +419,6 @@ zed backup restore <filename> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed context`
 
 Manage configurations for connecting to SpiceDB deployments
@@ -459,11 +444,10 @@ Manage configurations for connecting to SpiceDB deployments
 
 ### Children commands
 
-- [zed context list](#reference-zed-context-list)	 - Lists all available contexts
-- [zed context remove](#reference-zed-context-remove)	 - Removes a context by name
-- [zed context set](#reference-zed-context-set)	 - Creates or overwrite a context
-- [zed context use](#reference-zed-context-use)	 - Sets a context as the current context
-
+- [zed context list](#reference-zed-context-list) - Lists all available contexts
+- [zed context remove](#reference-zed-context-remove) - Removes a context by name
+- [zed context set](#reference-zed-context-set) - Creates or overwrite a context
+- [zed context use](#reference-zed-context-use) - Sets a context as the current context
 
 ## Reference: `zed context list`
 
@@ -498,8 +482,6 @@ zed context list [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed context remove`
 
 Removes a context by name
@@ -526,8 +508,6 @@ zed context remove <name>
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed context set`
 
@@ -556,8 +536,6 @@ zed context set <name> <endpoint> <api-token>
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed context use`
 
 Sets a context as the current context
@@ -584,8 +562,6 @@ zed context use <name>
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed import`
 
@@ -657,8 +633,6 @@ zed import <url> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed mcp`
 
 MCP (Model Context Protocol) server commands.
@@ -688,8 +662,7 @@ To use with Claude Code, run `zed mcp experimental-run` to start the SpiceDB Dev
 
 ### Children commands
 
-- [zed mcp experimental-run](#reference-zed-mcp-experimental-run)	 - Run the Experimental MCP server
-
+- [zed mcp experimental-run](#reference-zed-mcp-experimental-run) - Run the Experimental MCP server
 
 ## Reference: `zed mcp experimental-run`
 
@@ -724,8 +697,6 @@ zed mcp experimental-run [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed permission`
 
 Query the permissions in a permissions system
@@ -751,12 +722,11 @@ Query the permissions in a permissions system
 
 ### Children commands
 
-- [zed permission bulk](#reference-zed-permission-bulk)	 - Check permissions in bulk exist for resource-permission-subject triplets
-- [zed permission check](#reference-zed-permission-check)	 - Check if a subject has permission on a resource
-- [zed permission expand](#reference-zed-permission-expand)	 - Expand the structure of a permission
-- [zed permission lookup-resources](#reference-zed-permission-lookup-resources)	 - Enumerates the resources of a given type for which a subject has permission
-- [zed permission lookup-subjects](#reference-zed-permission-lookup-subjects)	 - Enumerates the subjects of a given type for which the subject has permission on the resource
-
+- [zed permission bulk](#reference-zed-permission-bulk) - Check permissions in bulk exist for resource-permission-subject triplets
+- [zed permission check](#reference-zed-permission-check) - Check if a subject has permission on a resource
+- [zed permission expand](#reference-zed-permission-expand) - Expand the structure of a permission
+- [zed permission lookup-resources](#reference-zed-permission-lookup-resources) - Enumerates the resources of a given type for which a subject has permission
+- [zed permission lookup-subjects](#reference-zed-permission-lookup-subjects) - Enumerates the subjects of a given type for which the subject has permission on the resource
 
 ## Reference: `zed permission bulk`
 
@@ -797,8 +767,6 @@ zed permission bulk <resource:id#permission@subject:id> <resource:id#permission@
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed permission check`
 
@@ -841,8 +809,6 @@ zed permission check <resource:id> <permission> <subject:id> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed permission expand`
 
 Expand the structure of a permission
@@ -880,8 +846,6 @@ zed permission expand <permission> <resource:id> [flags]
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed permission lookup-resources`
 
@@ -925,8 +889,6 @@ zed permission lookup-resources <type> <permission> <subject:id> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed permission lookup-subjects`
 
 Enumerates the subjects of a given type for which the subject has permission on the resource
@@ -966,8 +928,6 @@ zed permission lookup-subjects <resource:id> <permission> <subject_type#optional
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed preview schema compile`
 
 Compile a schema that uses extended syntax into one that can be written to SpiceDB
@@ -984,7 +944,7 @@ zed preview schema compile <file> [flags]
 		zed preview schema compile root.zed
 	Write to an output file:
 		zed preview schema compile root.zed --out compiled.zed
-	
+
 ```
 
 ### Options
@@ -1012,8 +972,6 @@ zed preview schema compile <file> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed relationship`
 
 Query and mutate the relationships in a permissions system
@@ -1039,13 +997,12 @@ Query and mutate the relationships in a permissions system
 
 ### Children commands
 
-- [zed relationship bulk-delete](#reference-zed-relationship-bulk-delete)	 - Deletes relationships matching the provided pattern en masse
-- [zed relationship create](#reference-zed-relationship-create)	 - Create a relationship for a subject
-- [zed relationship delete](#reference-zed-relationship-delete)	 - Deletes a relationship
-- [zed relationship read](#reference-zed-relationship-read)	 - Enumerates relationships matching the provided pattern
-- [zed relationship touch](#reference-zed-relationship-touch)	 - Idempotently updates a relationship for a subject
-- [zed relationship watch](#reference-zed-relationship-watch)	 - Watches the stream of relationship updates and schema updates from the server
-
+- [zed relationship bulk-delete](#reference-zed-relationship-bulk-delete) - Deletes relationships matching the provided pattern en masse
+- [zed relationship create](#reference-zed-relationship-create) - Create a relationship for a subject
+- [zed relationship delete](#reference-zed-relationship-delete) - Deletes a relationship
+- [zed relationship read](#reference-zed-relationship-read) - Enumerates relationships matching the provided pattern
+- [zed relationship touch](#reference-zed-relationship-touch) - Idempotently updates a relationship for a subject
+- [zed relationship watch](#reference-zed-relationship-watch) - Watches the stream of relationship updates and schema updates from the server
 
 ## Reference: `zed relationship bulk-delete`
 
@@ -1081,8 +1038,6 @@ zed relationship bulk-delete <resource_type:optional_resource_id> <optional_rela
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed relationship create`
 
@@ -1129,8 +1084,6 @@ zed relationship create <resource:id> <relation> <subject:id#optional_subject_re
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed relationship delete`
 
 Deletes a relationship
@@ -1164,8 +1117,6 @@ zed relationship delete <resource:id> <relation> <subject:id#optional_subject_re
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed relationship read`
 
@@ -1215,8 +1166,6 @@ zed relationship read <resource_type:optional_resource_id> <optional_relation> <
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed relationship touch`
 
 Idempotently updates a relationship for a subject
@@ -1261,8 +1210,6 @@ zed relationship touch <resource:id> <relation> <subject:id#optional_subject_rel
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed relationship watch`
 
@@ -1310,8 +1257,6 @@ zed relationship watch --filter document:finance#view@user:anne
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed schema`
 
 Manage schema for a permissions system
@@ -1337,12 +1282,11 @@ Manage schema for a permissions system
 
 ### Children commands
 
-- [zed schema compile](#reference-zed-schema-compile)	 - Compile a schema that uses extended syntax into one that can be written to SpiceDB
-- [zed schema copy](#reference-zed-schema-copy)	 - Copy a schema from one context into another
-- [zed schema diff](#reference-zed-schema-diff)	 - Diff two schema files
-- [zed schema read](#reference-zed-schema-read)	 - Read the schema of a permissions system
-- [zed schema write](#reference-zed-schema-write)	 - Write a schema file (.zed or stdin) to the current permissions system
-
+- [zed schema compile](#reference-zed-schema-compile) - Compile a schema that uses extended syntax into one that can be written to SpiceDB
+- [zed schema copy](#reference-zed-schema-copy) - Copy a schema from one context into another
+- [zed schema diff](#reference-zed-schema-diff) - Diff two schema files
+- [zed schema read](#reference-zed-schema-read) - Read the schema of a permissions system
+- [zed schema write](#reference-zed-schema-write) - Write a schema file (.zed or stdin) to the current permissions system
 
 ## Reference: `zed schema copy`
 
@@ -1378,8 +1322,6 @@ zed schema copy <src context> <dest context> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed schema diff`
 
 Diff two schema files
@@ -1406,8 +1348,6 @@ zed schema diff <before file> <after file>
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed schema read`
 
@@ -1441,8 +1381,6 @@ zed schema read [flags]
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed schema write`
 
@@ -1489,8 +1427,6 @@ zed schema write <file?> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed use`
 
 Alias for `zed context use`
@@ -1517,8 +1453,6 @@ zed use <context>
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
 
 ## Reference: `zed validate`
 
@@ -1578,8 +1512,6 @@ zed validate <validation_file_or_schema_file> [flags]
       --token string                token used to authenticate to SpiceDB
 ```
 
-
-
 ## Reference: `zed version`
 
 Display zed and SpiceDB version information
@@ -1613,6 +1545,3 @@ zed version [flags]
       --skip-version-check          if true, no version check is performed against the server
       --token string                token used to authenticate to SpiceDB
 ```
-
-
-

--- a/app/spicedb/getting-started/protecting-a-blog/page.mdx
+++ b/app/spicedb/getting-started/protecting-a-blog/page.mdx
@@ -648,17 +648,10 @@ For example, in our example schema, writers have both write and read permissions
 Let's perform some permission checks:
 
 <Callout type="info">
-When developing locally with SpiceDB running without TLS (`--grpc-no-tls`), use insecure credentials:
-- **Node.js**: `v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS`
-- **Python**: `insecure_bearer_token_credentials()`
-- **Go**: `grpcutil.WithInsecureBearerToken()` + `grpc.WithTransportCredentials(insecure.NewCredentials())`
-- **Ruby**: `credentials: :this_channel_is_insecure`
-- **Java**: `.usePlaintext()`
-- **Dotnet**: `ChannelCredentials.Insecure` with `UnsafeUseInsecureChannelCallCredentials = true` (requires `AppContext.SetSwitch` for HTTP/2)
-
-For TLS with self-signed certificates, use `v1.ClientSecurity.INSECURE_LOCALHOST_ALLOWED` (Node.js) instead. **Warning:** This skips CA verification and is only safe for localhost - never use against remote endpoints.
-
-See [Client Libraries](./client-libraries#local-development) for full details. Always switch to secure credentials before production.
+  If developing locally against SpiceDB, see
+  [this](./client-libraries#local-development) for full details on how to setup
+  credentials. Always switch to secure credentials before launching to
+  production.
 </Callout>
 
 <Tabs items={['zed', 'Node', 'Go', 'Python', 'Ruby', 'Java']}>

--- a/app/spicedb/ops/data/bulk-operations/page.mdx
+++ b/app/spicedb/ops/data/bulk-operations/page.mdx
@@ -24,7 +24,7 @@ We'll use the [authzed-dotnet](https://github.com/authzed/authzed-dotnet) client
 Other client libraries will have different syntax and structures around their streaming and iteration,
 but this should demonstrate the two different levels of chunking that we'll do in the process.
 
-<Tabs items={["Dotnet", "Python"]}>
+<Tabs items={[".NET", "Python"]}>
     <Tabs.Tab>
         ```csharp
         var TOTAL_RELATIONSHIPS_TO_WRITE = 1000;


### PR DESCRIPTION
Addresses #350 by clarifying when to use `INSECURE_PLAINTEXT_CREDENTIALS` vs `INSECURE_LOCALHOST_ALLOWED` for local development scenarios.

## Changes
- Added Local Development section to client-libraries.mdx with insecure credential options for all supported languages
- Added callout in protecting-a-blog.mdx explaining insecure credentials for all client libraries
- Updated Node.js code example comment for clarity

## Context
Teams using Orbstack or Docker with non-localhost hostnames (e.g., `*.orb.local`) were confused about which security setting to use. This makes it clear that insecure plaintext credentials work for all local development scenarios including localhost, Docker, Orbstack, and other non-TLS setups.

Fixes #350