### PR TITLE
Add "use" to list of new keywords

### DIFF
--- a/pages/spicedb/modeling/composable-schemas.mdx
+++ b/pages/spicedb/modeling/composable-schemas.mdx
@@ -71,7 +71,7 @@ written to SpiceDB but not compiled.
 
 The obvious breaking changes are `import` and `partial` becoming keywords, so if you have a permission or
 relation with those names, your schema can't be compiled.
-We have also reserved some keywords for future use, such as `and`, `or`, and `not`.
+We have also reserved some keywords for future use, such as `use`, `and`, `or`, and `not`.
 If you get an unexpected `TokenTypeKeyword` error, this is probably why.
 A full list of reserved keywords can be found in [`keyword` map definition](https://github.com/authzed/spicedb/blob/main/pkg/composableschemadsl/lexer/lex_def.go#L74) in the lexer.
 


### PR DESCRIPTION
Fixes #405 

## Description
A user asked why they got `zed validate` failures with a permission named `use` in a schema that used composable schema syntax. We added `use` to the list of reserved keywords in that version of the parser, so this updates the docs to explicitly list it.

## Changes
* Add `use`
## Testing
Review.