### PR TITLE
Fix link to mcp docs

### DIFF
--- a/pages/spicedb/getting-started/faq.mdx
+++ b/pages/spicedb/getting-started/faq.mdx
@@ -43,7 +43,7 @@ Notably, policy engines cannot implement [Reverse Indices].
 However, there are some scenarios where ReBAC systems can benefit from dynamic enforcement.
 For these scenarios, SpiceDB supports [Caveats] as a light-weight form of policy that avoids pitfalls present in many other systems.
 
-[Reverse Indices]: ../faq/reverse-indices
+[Reverse Indices]: ../concepts/zanzibar/#reverse-indices
 [caveats]: ../concepts/caveats
 
 ## How can I get involved with SpiceDB?

--- a/pages/spicedb/modeling/_meta.json
+++ b/pages/spicedb/modeling/_meta.json
@@ -11,6 +11,6 @@
   "attributes": "Incorporating Attributes",
   "dev-mcp-server": {
     "title": "SpiceDB Dev MCP Server",
-    "href": "../../mcp/authzed/spicedb-dev-mcp-server"
+    "href": "/mcp/authzed/spicedb-dev-mcp-server"
   }
 }


### PR DESCRIPTION
## Description
The current link is showing as page-relative rather than root-relative for whatever reason. This should make it root-relative.

This is causing the link checker to fail.

## Changes
* Remove leading dots from mcp link
## Testing
Review