### PR TITLE
migration clarifications

### DIFF
--- a/pages/spicedb/concepts/datastore-migrations.mdx
+++ b/pages/spicedb/concepts/datastore-migrations.mdx
@@ -8,6 +8,10 @@ Updates are published to the [SpiceDB GitHub releases page] and announced via [T
 Transitioning between versions is often as simple as executing a new binary or container, but there are times when updates are more complex.
 For example, releases that include changes to datastore can require that users update to specific versions and perform a series of actions in order to update while avoiding any downtime.
 
+<Callout type="info">
+    This page explains migrating the schema of a datastore underlying SpiceDB. If you need information about migrating between SpiceDB instances, go [here](/spicedb/ops/data/migrations). If you need information about making changes to a SpiceDB schema that result in a migration, go [here](/spicedb/modeling/migrating-schema).
+</Callout>
+
 <Callout type="warning">
   SpiceDB strives to main compatibility across each version and its following minor version.
 

--- a/pages/spicedb/modeling/migrating-schema.mdx
+++ b/pages/spicedb/modeling/migrating-schema.mdx
@@ -1,6 +1,10 @@
 import { Callout } from 'nextra/components';
 
-# Updating Migrating Schema in SpiceDB
+# Updating and Migrating Schema in SpiceDB
+
+<Callout type="info">
+    This page explains how to modify a SpiceDB schema. If you need information about migrating the schema of a datastore underlying SpiceDB, like Postgres or CockroachDB, go [here](/spicedb/concepts/datastore-migrations#migrations). If you need information about migrating between SpiceDB instances, go [here](/spicedb/ops/data/migrations).
+</Callout>
 
 [Schema] in SpiceDB represents the structural definitions of which relationships are allowed
 in SpiceDB and how permissions are computed.

--- a/pages/spicedb/ops/data/migrations.mdx
+++ b/pages/spicedb/ops/data/migrations.mdx
@@ -2,7 +2,12 @@ import { Callout } from 'nextra/components'
 
 # Migrations
 
+
 ## Migrating from SpiceDB to SpiceDB
+
+<Callout type="info">
+    This section covers migrating data from one SpiceDB instance to another. If you need information about migrating the schema of a datastore underlying SpiceDB, like Postgres or CockroachDB, go [here](/spicedb/concepts/datastore-migrations#migrations). If you need information about making changes to a SpiceDB schema that result in a migration, go [here](/spicedb/modeling/migrating-schema).
+</Callout>
 
 <Callout type="warning">
     Migrating data at the underlying database level is not recommended and impossible in some cases. Using tools like `pg_dump`/`pg_restore` will break SpiceDB MVCC. Additionally, if you are migrating to a SpiceDB with a different datastore type (e.g. Postgres -> CockroachDB), you ***must*** use the SpiceDB APIs (`exportBulk`/`importBulk` or `zed backup`) to backup and restore.


### PR DESCRIPTION
Users are getting confused about the various meanings of migrations, so I added info boxes to help people find their way to the docs page that gives info about the kind of migration the user is looking for.