### PR TITLE
Update watch metadata docs to fix `Struct` construction

### DIFF
--- a/pages/spicedb/concepts/watch.mdx
+++ b/pages/spicedb/concepts/watch.mdx
@@ -144,6 +144,8 @@ client = Client(
     "localhost:50051",
     bearer_token_credentials("your-token-here"),
 )
+metadata = Struct()
+metadata.update({"request_id": "12345"})
 client.WriteRelationships(WriteRelationshipsRequest(
   updates=[
       RelationshipUpdate(
@@ -160,7 +162,7 @@ client.WriteRelationships(WriteRelationshipsRequest(
                 ),
       ),
   ],
-  optional_transaction_metadata=Struct({"request_id": "12345"}),
+  optional_transaction_metadata=metadata,
 })
 
 ...


### PR DESCRIPTION
## Description
Follow-on to authzed/authzed-py#302. I never actually ran that test so the syntax was wrong, and then the syntax got documented here.

## Changes
Fix struct construction in the example

## Testing
Review.