### PR TITLE
Fix csp for search bar

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
         {
           "key": "x-robots-tag",
           "value": "index, follow"
+        },
+        {
+          "key": "content-security-policy",
+          "value": "default-src 'self' docs-authzed.vercel.app"
         }
       ]
     },


### PR DESCRIPTION
## Description
<img width="972" height="313" alt="image" src="https://github.com/user-attachments/assets/fb8fc2fa-96d8-4e3f-95b7-f7921afe128e" />

The issue here is that the JS for the search bar is dynamically imported, and it comes from the CDN domain, not from `authzed.com`. Chrome (though interestingly not firefox) treats this as a CSP violation even without a CSP set; setting an explicit CSP should fix this.

## Changes
* Add a simple CSP that sets `default-src` to include our CDN
## Testing
Review