### PR TITLE
Fix csp header attempt 2

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -32,6 +32,10 @@
         {
           "key": "x-robots-tag",
           "value": "index, follow"
+        },
+        {
+          "key": "content-security-policy",
+          "value": "default-src 'self' authzed.com;"
         }
       ]
     }


### PR DESCRIPTION
## Description
See #442.

The realization i had is that the script requesting the pagefind script is served from `docs-authzed.vercel.app` (i.e. the CDN) and is requesting the new script from `authzed.com`.

I didn't have a CSP on the CDN, so I added one that points at authzed.com. Hopefully this fixes things.

## Changes
* Add CSP to CDN that points at authzed.com
## Testing
Review.