### PR TITLE
Fix CSP with unsafe-inline

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
         },
         {
           "key": "content-security-policy",
-          "value": "default-src 'self' docs-authzed.vercel.app;"
+          "value": "default-src 'self' docs-authzed.vercel.app unsafe-inline;"
         }
       ]
     },
@@ -35,7 +35,7 @@
         },
         {
           "key": "content-security-policy",
-          "value": "default-src 'self' authzed.com;"
+          "value": "default-src 'self' authzed.com unsafe-inline;"
         }
       ]
     }


### PR DESCRIPTION
## Description
There's definitely a better CSP to be had here, but `unsafe-inline` will fix the break that #443 caused.

## Changes
* Add `unsafe-inline` to `default-src`

## Testing
Review. Deploy and see what happens.