### PR TITLE
Make csps match

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
         },
         {
           "key": "content-security-policy",
-          "value": "default-src 'self' docs-authzed.vercel.app 'unsafe-inline';"
+          "value": "default-src 'self' docs-authzed.vercel.app authzed.com 'unsafe-inline';"
         }
       ]
     },
@@ -35,7 +35,7 @@
         },
         {
           "key": "content-security-policy",
-          "value": "default-src 'self' authzed.com 'unsafe-inline';"
+          "value": "default-src 'self' docs-authzed.vercel.app authzed.com 'unsafe-inline';"
         }
       ]
     }


### PR DESCRIPTION
## Description
```
Loading the script 'https://docs-authzed.vercel.app/docs/_next/static/chunks/b542f544-ea2bdd057dfb27cd.js' violates the following Content Security Policy directive: "default-src 'self' authzed.com 'unsafe-inline'". Note that 'script-src-elem' was not explicitly set, so 'default-src' is used as a fallback. The action has been blocked.
```
I'm not sure why this doesn't fall under `'self'`. I'm guessing this is some vercel weirdness. I wish they had this documented somewhere.

I'm trying the approach of adding both domains to both CSPs.

## Changes
* Add both domains to both CSPs.
## Testing
Review.