### PR TITLE
Set cross-origin on script tags

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,9 @@ const withNextra = nextra({
 
 export default withNextra({
   basePath: process.env.NEXT_PUBLIC_BASE_DIR ?? undefined,
+  // This is necessary because we're using CDN domains.
+  // It adds `cross-origin="anonymous"` to script tags
+  crossOrigin: "anonymous",
   assetPrefix:
     process.env.VERCEL_ENV === "production"
       ? "https://docs-authzed.vercel.app/docs"


### PR DESCRIPTION
## Description
This SO issue seems to match what we're seeing: https://stackoverflow.com/questions/71872980/cors-cross-origin-error-on-dynamic-load-of-resource

Namely that it's only in Chrome.

This is how you set those in next: https://nextjs.org/docs/15/app/api-reference/config/next-config-js/crossOrigin

## Changes
* Add `crossOrigin` setting
## Testing
Review.