### PR TITLE
Remove references to --grpc-no-tls flag

### DIFF
--- a/app/spicedb/getting-started/client-libraries/page.mdx
+++ b/app/spicedb/getting-started/client-libraries/page.mdx
@@ -24,7 +24,7 @@ When developing locally, you'll need to configure your client based on how Spice
 
 ### SpiceDB running without TLS (most common)
 
-If SpiceDB is started without TLS (using `--grpc-no-tls`), use insecure plaintext credentials:
+If SpiceDB is started without TLS, use insecure plaintext credentials:
 
 <Tabs items={["Node", "Go", "Python", "Ruby", "Java", ".NET"]}>
   <Tabs.Tab>`v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS`</Tabs.Tab>

--- a/app/spicedb/ops/spicedb-langchain-langgraph-rag/page.mdx
+++ b/app/spicedb/ops/spicedb-langchain-langgraph-rag/page.mdx
@@ -33,7 +33,7 @@ The library implements **post-filter authorization**, meaning:
 To run locally, use:
 
 ```bash
-docker run --rm -p 50051:50051 authzed/spicedb serve --grpc-preshared-key "sometoken" --grpc-no-tls
+docker run --rm -p 50051:50051 authzed/spicedb serve --grpc-preshared-key "sometoken"
 ```
 
 ---


### PR DESCRIPTION
Fixes #475 
## Description

The --grcp-no-tls flag is no longer supported.

## References

#475 