### PR TITLE
docs: fix missing preposition in schema page

### DIFF
--- a/app/spicedb/concepts/schema/page.mdx
+++ b/app/spicedb/concepts/schema/page.mdx
@@ -4,7 +4,7 @@ import { InlinePlayground } from "@/components/playground";
 
 # Schema Language Reference
 
-A SpiceDB schema defines the types of objects found your application, how those objects can relate to one another, and the permissions that can be computed off of those relations.
+A SpiceDB schema defines the types of objects found within your application, how those objects can relate to one another, and the permissions that can be computed off of those relations.
 
 This page is a reference guide that uses examples that are loosely based on trying to write a schema for Google Docs. For a detailed guide on how to write your own schema from scratch, see [Developing a Schema].
 


### PR DESCRIPTION
## Description

This PR fixes a grammatical error on the SpiceDB schema concepts page. The sentence was missing the preposition "within" after "found." It now reads correctly as "found within your application."

## Testing

This is a documentation-only change. I verified the fix by reviewing the rendered content locally. No functional code changes were made, so no additional testing is required.

## References

None