### PR TITLE
Fix nesting of response/metadata in CheckPermission audit log example

### DIFF
--- a/app/authzed/concepts/audit-logging/page.mdx
+++ b/app/authzed/concepts/audit-logging/page.mdx
@@ -43,19 +43,19 @@ Logs contain the full details related to a request including:
           "objectType": "user",
           "objectId": "tom"
         }
-      },
-      "response": {
-        "@type": "type.googleapis.com/authzed.api.v1.CheckPermissionResponse",
-        "checkedAt": {
-          "token": "GgoKCENKcmt4QTA9"
-        },
-        "permissionship": "PERMISSIONSHIP_HAS_PERMISSION"
-      },
-      "metadata": {
-        "token_hash": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
-        "user-agent": "grpc-go/1.58.3",
-        "x-request-id": "819b4d52db4797491e31d0228f381543"
       }
+    },
+    "response": {
+      "@type": "type.googleapis.com/authzed.api.v1.CheckPermissionResponse",
+      "checkedAt": {
+        "token": "GgoKCENKcmt4QTA9"
+      },
+      "permissionship": "PERMISSIONSHIP_HAS_PERMISSION"
+    },
+    "metadata": {
+      "token_hash": "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+      "user-agent": "grpc-go/1.58.3",
+      "x-request-id": "819b4d52db4797491e31d0228f381543"
     }
   }
 }


### PR DESCRIPTION
## Summary

In the Audit Logging docs, the CheckPermission JSON example incorrectly nested the `response` and `metadata` fields *inside* the `request` object.

Per the `Audit` proto, `request`, `response`, `error`, and `metadata` are sibling fields:

```proto
message Audit {
  google.protobuf.Any request = 1;
  google.protobuf.Any response = 2;
  google.protobuf.Any error = 3;
  map<string, string> metadata = 4;
}
```

This now matches the correctly-formatted ReadSchema example directly below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)