### PR TITLE
docs(materialize): remove author draft/TODO callouts from concept pages

### DIFF
--- a/app/materialize/concepts/permission-set-lifecycle/page.mdx
+++ b/app/materialize/concepts/permission-set-lifecycle/page.mdx
@@ -2,12 +2,6 @@ import { Callout } from "nextra/components";
 
 # The permission set lifecycle
 
-<Callout type="info">
-  **Draft — content review needed.** This concept page was promoted from prose that previously lived
-  inline in the API reference. The mechanics below are accurate to the existing docs; the framing is
-  new and should be reviewed (and expanded with diagrams/examples) before publishing.
-</Callout>
-
 The **permission set lifecycle** describes how your application's local copy of permission data is populated, kept current, and rebuilt over time — from an empty index to a complete, queryable [Permission Sets](./permission-sets) store, and back to a fresh index when your schema changes.
 
 When you first bring a system online, you have no permission data locally.
@@ -33,10 +27,3 @@ Once the backfill is complete, you switch to [WatchPermissionSets](../../api/wat
 A backfill always produces a [snapshot](./snapshots) — a point-in-time, internally consistent view of the permission sets at a specific revision.
 The relationship is one-directional: **the backfill is the act; a snapshot is the result.**
 You backfill _to_ a snapshot revision, then keep that snapshot live with the change stream.
-
-<Callout type="info">
-  **TODO:** add a dedicated `DownloadPermissionSets` (Download API) reference page — it's the
-  recommended backfill path but has no reference page yet. **TODO (Sam):** expand with a concrete
-  worked example and the four-phase / blue-green re-backfill strategy for breaking schema changes,
-  currently documented under [LookupPermissionSets](../../api/lookup-permission-sets).
-</Callout>

--- a/app/materialize/concepts/snapshots/page.mdx
+++ b/app/materialize/concepts/snapshots/page.mdx
@@ -2,12 +2,6 @@ import { Callout } from "nextra/components";
 
 # Snapshots
 
-<Callout type="info">
-  **Draft — content review needed.** Promoted from prose previously scattered through the API
-  reference. Mechanics are accurate to the existing docs; framing is new and should be reviewed
-  before publishing.
-</Callout>
-
 A **snapshot** is a point-in-time, internally consistent view of every [Permission Set](./permission-sets) Materialize is tracking, computed at a specific SpiceDB revision.
 Every piece of permission data Materialize hands you is anchored to the revision (`ZedToken`) it was computed at — that revision _is_ the snapshot's identity.
 
@@ -31,9 +25,4 @@ Storing the snapshot revision **in the same transaction** as the permission data
   After a breaking schema change you **must** pass the revision token through `optional_starting_after`
   when re-running the backfill, or Materialize will stream against whatever snapshot is current and
   your data won't reflect the schema change.
-</Callout>
-
-<Callout type="info">
-  **TODO (Sam):** confirm the exact snapshot retention window and rotation cadence, and whether the
-  24h change-event retention is the same mechanism or distinct.
 </Callout>


### PR DESCRIPTION
Follow-up to #562. The Materialize concept pages shipped with author-to-author
`<Callout>` notes that render as live info/warning boxes to readers. This removes
them from both pages:

**`app/materialize/concepts/permission-set-lifecycle/page.mdx`**
- "Draft — content review needed" banner
- TODO callout: DownloadPermissionSets reference page + worked-example expansion

**`app/materialize/concepts/snapshots/page.mdx`**
- "Draft — content review needed" banner
- TODO callout: snapshot retention-window confirmation

The underlying follow-up work (a `DownloadPermissionSets` reference page, a worked
backfill example, and confirming snapshot retention/rotation) is tracked separately —
this PR just stops the notes from rendering to readers. The nextra `Callout` import
stays; both pages still use it for genuine reader-facing callouts.
