### PR TITLE
docs: fix broken doc links (redirects + dead card link)

### DIFF
--- a/app/spicedb/getting-started/first-steps/page.mdx
+++ b/app/spicedb/getting-started/first-steps/page.mdx
@@ -72,7 +72,7 @@ import { InlinePlayground } from "@/components/playground";
     Follow the instructions below to install to your development machine:
 
     <Cards num={2}>
-        <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faServer} />} title="Install the SpiceDB server binary" href="/spicedb/getting-started/install/macos" />
+        <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faServer} />} title="Install the SpiceDB server binary" href="/spicedb/getting-started/install/docker" />
         <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faTerminal} />} title="Install the SpiceDB CLI tool: Zed" href="/spicedb/getting-started/installing-zed" />
     </Cards>
 

--- a/app/spicedb/getting-started/first-steps/page.mdx
+++ b/app/spicedb/getting-started/first-steps/page.mdx
@@ -72,7 +72,7 @@ import { InlinePlayground } from "@/components/playground";
     Follow the instructions below to install to your development machine:
 
     <Cards num={2}>
-        <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faServer} />} title="Install the SpiceDB server binary" href="/spicedb/getting-started/installing-spicedb" />
+        <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faServer} />} title="Install the SpiceDB server binary" href="/spicedb/getting-started/install/macos" />
         <Cards.Card arrow={true} icon={<FontAwesomeIcon icon={faTerminal} />} title="Install the SpiceDB CLI tool: Zed" href="/spicedb/getting-started/installing-zed" />
     </Cards>
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -50,6 +50,33 @@ export default withNextra({
         destination: "/spicedb/best-practices/:path*",
         permanent: true,
       },
+      // Materialize was promoted from a single concept page to a top-level
+      // section (PR #562). Keep the old indexed URL working.
+      {
+        source: "/authzed/concepts/authzed-materialize",
+        destination: "/materialize/getting-started/overview",
+        permanent: true,
+      },
+      // The Ops pages below moved on 2026-02-05 without redirects, leaving
+      // ~2 months of indexed URLs 404ing. ai-agent-authorization and
+      // secure-rag-pipelines moved into the new Tutorials section; the
+      // langchain/langgraph RAG page was folded into the langchain-spicedb
+      // integration page.
+      {
+        source: "/spicedb/ops/ai-agent-authorization",
+        destination: "/spicedb/tutorials/ai-agent-authorization",
+        permanent: true,
+      },
+      {
+        source: "/spicedb/ops/secure-rag-pipelines",
+        destination: "/spicedb/tutorials/secure-rag-pipelines",
+        permanent: true,
+      },
+      {
+        source: "/spicedb/ops/spicedb-langchain-langgraph-rag",
+        destination: "/spicedb/integrations/langchain-spicedb",
+        permanent: true,
+      },
     ];
   },
   // This is necessary because we're using CDN domains.


### PR DESCRIPTION
## What

A sweep for broken doc links after recent page moves. Two kinds of fix.

### Redirects (`next.config.mjs`) — moved/removed pages leaving indexed URLs 404ing

| Old URL (404s today) | Redirects to | When it broke |
|---|---|---|
| `/authzed/concepts/authzed-materialize` | `/materialize/getting-started/overview` | #562 (promoted to top-level section) |
| `/spicedb/ops/ai-agent-authorization` | `/spicedb/tutorials/ai-agent-authorization` | 2026-02-05 (moved to Tutorials) |
| `/spicedb/ops/secure-rag-pipelines` | `/spicedb/tutorials/secure-rag-pipelines` | 2026-02-05 (moved to Tutorials) |
| `/spicedb/ops/spicedb-langchain-langgraph-rag` | `/spicedb/integrations/langchain-spicedb` | 2026-02-05 (folded into integration page) |

The three `/spicedb/ops/*` pages were live ~2 months (since the Nextra v4 upgrade) before moving, so they're the most likely to be indexed. Permanent (308) redirects following the existing best-practices pattern; sources are basePath-relative; browsers preserve any `#fragment`.

### Dead internal link

The `getting-started/first-steps` **"Install the SpiceDB server binary"** card pointed at `/spicedb/getting-started/installing-spicedb` — a path that never existed (install docs live under `install/<os>`). Repointed to `install/macos`, matching how the rest of the site links to install docs.

## How this was verified

- Git history since the Nextra v4 upgrade — every deleted/renamed `page.*` accounted for.
- Built a route map from `app/` and checked every absolute + fully-qualified (`authzed.com/docs/...`) internal link against it: 0 broken after the card fix.
- Relative `](./sibling)` links resolve correctly in Nextra (verified), not broken.

## Not included

Two Materialize pages (`concepts/hydration`, `api/download-api`) were created and removed entirely within the #562 branch before merge — never shipped to production, so no redirect needed.