### PR TITLE
fix: serve docs assets from the same origin as pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,11 +79,6 @@ export default withNextra({
       },
     ];
   },
-  // This is necessary because we're using CDN domains.
-  // It adds `cross-origin="anonymous"` to script tags
-  crossOrigin: "anonymous",
-  assetPrefix:
-    process.env.VERCEL_ENV === "production" ? "https://docs-authzed.vercel.app/docs" : undefined,
   // NOTE: we still use webpack instead of turbopack for dev
   // because turbopack doesn't support non-serializable nextjs options.
   // The rehypePrettyCodeOptions in the block above include a function,


### PR DESCRIPTION
Fixes #478.

Docs pages are served from `authzed.com/docs` but their assets (JS/CSS/fonts) were loaded from a second domain (`docs-authzed.vercel.app`) via `assetPrefix`, which breaks for users behind restrictive firewalls.

Removes the production `assetPrefix` (and the `crossOrigin: "anonymous"` that only existed to support the cross-origin CDN). 