### PR TITLE
docs: repair 7 broken internal links

### DIFF
--- a/app/materialize/api/download-permission-sets/page.mdx
+++ b/app/materialize/api/download-permission-sets/page.mdx
@@ -9,7 +9,7 @@ import { Callout } from "nextra/components";
 
 <FeatureBadge />
 
-For large datasets, `DownloadPermissionSets` is a faster alternative to [LookupPermissionSets] for the initial [backfill](./concepts/permission-set-lifecycle): instead of streaming individual events over a single connection, it hands you a manifest of files you can fetch directly from blob storage, in parallel.
+For large datasets, `DownloadPermissionSets` is a faster alternative to [LookupPermissionSets] for the initial [backfill](../concepts/permission-set-lifecycle): instead of streaming individual events over a single connection, it hands you a manifest of files you can fetch directly from blob storage, in parallel.
 
 ## Request
 
@@ -23,7 +23,7 @@ The request maps to [`DownloadPermissionSetsRequest`]:
 
 If `optional_at_revision` is omitted, Materialize returns files for the latest fully-published revision. If provided, Materialize returns files for that specific revision if they're still available (see [Snapshot rotation](../concepts/snapshots#snapshot-lifecycle-events)).
 
-Once you've backfilled from the downloaded files, switch to [WatchPermissionSets] to keep your copy current. See [The Permission Set Lifecycle](./concepts/permission-set-lifecycle) for the full flow.
+Once you've backfilled from the downloaded files, switch to [WatchPermissionSets] to keep your copy current. See [The Permission Set Lifecycle](../concepts/permission-set-lifecycle) for the full flow.
 
 ## Response
 

--- a/app/materialize/concepts/snapshots/page.mdx
+++ b/app/materialize/concepts/snapshots/page.mdx
@@ -18,7 +18,7 @@ A permission set snapshot is a further step removed: it's what Materialize has c
 Internally, AuthZed engineers sometimes call this a **groupstore**.
 On this page, "snapshot" always refers to the permission set snapshot unless stated otherwise.
 
-[spicedb-revision]: https://authzed.com/docs/spicedb/concepts/consistency#zedtokens
+[spicedb-revision]: /spicedb/concepts/consistency#zedtokens
 
 Permission set snapshots underpin both Materialize features: they're what Materialize [hydrates](./hydration) in order to answer Accelerated Queries, and they're what make the Event Streams APIs compose safely:
 

--- a/app/materialize/concepts/watched-permissions/page.mdx
+++ b/app/materialize/concepts/watched-permissions/page.mdx
@@ -48,6 +48,6 @@ The permission's path also can't cross any of the schema features Materialize do
   permissions.
 </Callout>
 
-[Caveats]: https://authzed.com/docs/spicedb/concepts/caveats
-[Wildcard]: https://authzed.com/docs/spicedb/concepts/schema#wildcards
-[.all intersections]: https://authzed.com/docs/spicedb/concepts/schema#all-intersection-arrow
+[Caveats]: /spicedb/concepts/caveats
+[Wildcard]: /spicedb/concepts/schema#wildcards
+[.all intersections]: /spicedb/concepts/schema#all-intersection-arrow

--- a/app/materialize/getting-started/limitations/page.mdx
+++ b/app/materialize/getting-started/limitations/page.mdx
@@ -15,8 +15,8 @@ description: "Current limitations of AuthZed Materialize, including caveats, wil
 - [Expiring relationships] aren't supported.
 - Materialize takes time to compute the denormalized relationship updates, so if you are streaming the changes to your database, your application must be able to tolerate some lag.
 
-[Caveats]: https://authzed.com/docs/spicedb/concepts/caveats
-[Wildcard]: https://authzed.com/docs/spicedb/concepts/schema#wildcards
-[.all intersections]: https://authzed.com/docs/spicedb/concepts/schema#all-intersection-arrow
-[expiring relationships]: https://authzed.com/docs/spicedb/concepts/expiring-relationships
-[Dedicated]: https://authzed.com/docs/authzed/guides/picking-a-product#dedicated
+[Caveats]: /spicedb/concepts/caveats
+[Wildcard]: /spicedb/concepts/schema#wildcards
+[.all intersections]: /spicedb/concepts/schema#all-intersection-arrow
+[expiring relationships]: /spicedb/concepts/expiring-relationships
+[Dedicated]: /authzed/guides/picking-a-product#dedicated

--- a/app/materialize/getting-started/overview/page.mdx
+++ b/app/materialize/getting-started/overview/page.mdx
@@ -42,7 +42,7 @@ Accelerated Queries use Materialize's precomputed permissions cache to answer th
 
 Event Streams let you take Materialize's precomputed permission data out of SpiceDB and keep your own copy of it — either colocated alongside the data it protects in your application database, or in a secondary index like a search engine.
 
-- Download the current state of every [permission set](../../concepts/permission-sets) with `LookupPermissionSets`, then keep it current in real time with `WatchPermissionSets`. See [The Permission Set Lifecycle](../../concepts/permission-set-lifecycle).
+- Download the current state of every [permission set](../concepts/permission-sets) with `LookupPermissionSets`, then keep it current in real time with `WatchPermissionSets`. See [The Permission Set Lifecycle](../concepts/permission-set-lifecycle).
 - Build authorization-aware UIs — sort, filter, and paginate over many thousands of authorized objects natively in your own database by colocating computed permissions next to your application data.
 - Perform ACL filtering in secondary indexes too, like a search index (e.g. Elasticsearch) — authorization-aware UIs and search-index filtering are the same idea (ACL filtering) applied to different stores.
 

--- a/app/materialize/getting-started/overview/page.mdx
+++ b/app/materialize/getting-started/overview/page.mdx
@@ -46,4 +46,4 @@ Event Streams let you take Materialize's precomputed permission data out of Spic
 - Build authorization-aware UIs — sort, filter, and paginate over many thousands of authorized objects natively in your own database by colocating computed permissions next to your application data.
 - Perform ACL filtering in secondary indexes too, like a search index (e.g. Elasticsearch) — authorization-aware UIs and search-index filtering are the same idea (ACL filtering) applied to different stores.
 
-[Dedicated]: https://authzed.com/docs/authzed/guides/picking-a-product#dedicated
+[Dedicated]: /authzed/guides/picking-a-product#dedicated

--- a/app/spicedb/getting-started/protecting-a-blog/page.mdx
+++ b/app/spicedb/getting-started/protecting-a-blog/page.mdx
@@ -28,7 +28,7 @@ docker run --rm -p 50051:50051 authzed/spicedb serve --grpc-preshared-key "t_you
 
 [Authzed Cloud]: https://authzed.com/cloud/signup
 [SpiceDB]: https://github.com/authzed/spicedb
-[running instance]: /spicedb/getting-started/installing-spicedb
+[running instance]: /spicedb/getting-started/install/docker
 
 ## Installing the Client
 

--- a/app/spicedb/ops/data/migrations/page.mdx
+++ b/app/spicedb/ops/data/migrations/page.mdx
@@ -28,7 +28,7 @@ This section covers migrating data from one SpiceDB instance to another with min
 
 ## Pre-requisites
 
-- [zed](../getting-started/installing-zed)
+- [zed](/spicedb/getting-started/installing-zed)
 
 ## Options
 

--- a/app/spicedb/tutorials/federated-authorization/page.mdx
+++ b/app/spicedb/tutorials/federated-authorization/page.mdx
@@ -14,7 +14,7 @@ Point them at an internal user you own, and bind each external account to it.
 ## Prerequisites
 
 - A running SpiceDB instance.
-  [Install SpiceDB](/spicedb/getting-started/install) and start it.
+  [Install SpiceDB](/spicedb/getting-started/install/docker) and start it.
 - The [`zed` CLI](/spicedb/getting-started/installing-zed), pointed at your instance:
 
   ```sh


### PR DESCRIPTION
Corey spotted dead links on `/materialize/getting-started/overview` — under **Event Streams**, both "permission set" and "The Permission Set Lifecycle" land on the SpiceDB FAQ. Confirmed, plus five more found in a full sweep.

### Root cause

Relative MDX hrefs are emitted raw into the HTML (`href="../../concepts/x"`) and resolved by the browser against a URL with **no trailing slash**. So `./x` is a **sibling**, not a child, and `../` climbs one level higher than it looks like it should.

### Introduced by #574 (materialize-feature-badges)

| File | Was | Resolved to | Live |
|---|---|---|---|
| `materialize/getting-started/overview` | `../../concepts/permission-sets` | `/docs/concepts/permission-sets` | 200 → redirects to SpiceDB FAQ |
| same | `../../concepts/permission-set-lifecycle` | `/docs/concepts/permission-set-lifecycle` | 200 → FAQ |
| `materialize/api/download-permission-sets` ×2 | `./concepts/permission-set-lifecycle` | `/docs/materialize/api/concepts/…` | 404 |

All four become `../concepts/…`. The `../concepts/snapshots#…` link already in `download-permission-sets` was correct and is the reference form.

### Pre-existing

- `spicedb/getting-started/protecting-a-blog` — the `[running instance]` reference definition pointed at `getting-started/installing-spicedb`, which no longer exists (same dead path #569 fixed on `first-steps`; this file was missed). → `install/docker`
- `spicedb/ops/data/migrations` — `../getting-started/installing-zed` resolved to `/spicedb/ops/getting-started/installing-zed` (404). Made absolute; the absolute path returns 200.
- `spicedb/tutorials/federated-authorization` — `/spicedb/getting-started/install` 404s: that directory has `_meta.ts` and six per-OS children but no `page.*`. → `install/docker`, matching the "Install the SpiceDB server binary" card on `first-steps`.

If an `install` index page is wanted later, that link can point back at the folder.

### Verification

- Every broken target confirmed against the live site by status code, and the broken hrefs confirmed in the **rendered** HTML, not just the source.
- Swept all 93 pages for relative-link resolution against the route map and `next.config.mjs` redirects. After this change the only remaining report is a false positive — a `[^1]: SpiceDB …` footnote matching the reference-definition pattern.
- All 10 `/images/*` references verified present in `public/`.
- `pnpm format:check` and `pnpm build` both green.

### Non-issue, for the record

Sidebar folder headings emit basePath-less hrefs (`/spicedb/getting-started/install`) that 404 if opened directly. This is Nextra's collapsible-group markup — `/spicedb/api`, `/spicedb/concepts`, and `/spicedb/getting-started` all behave the same way — and the anchors are intercepted client-side. Not touched here.